### PR TITLE
Show encoding results, and fix a verify-encoding issue.

### DIFF
--- a/bin/list_config_results
+++ b/bin/list_config_results
@@ -32,6 +32,7 @@ def main():
   parser.add_argument("--codec")
   parser.add_argument('--component')
   parser.add_argument('--criterion', default='psnr')
+  parser.add_argument('--show_result', action='store_true', default=False)
 
   args = parser.parse_args()
 
@@ -48,6 +49,10 @@ def main():
   for encoding in encodings:
     if args.component:
       component = encoding.result[args.component]
+    elif args.show_result:
+      result = encoding.result.copy()
+      del result['frame']  # per-frame data is too big to show
+      component = str(result)
     else:
       component = ''
     print '%s %f %s %s' % (encoding.encoder.Hashname(),

--- a/bin/verify_encodings
+++ b/bin/verify_encodings
@@ -24,12 +24,14 @@ import mpeg_settings
 import encoder
 import optimizer
 import pick_codec
+import score_tools
 
-def VerifyOneTarget(codecs, rate, videofile):
+def VerifyOneTarget(codecs, rate, videofile, criterion):
   change_count = 0
   for codec_name in codecs:
     codec = pick_codec.PickCodec(codec_name)
-    my_optimizer = optimizer.Optimizer(codec)
+    my_optimizer = optimizer.Optimizer(codec,
+        score_function=score_tools.PickScorer(criterion))
     bestsofar = my_optimizer.BestEncoding(rate, videofile)
     if not bestsofar.Result():
       print '%s rate %s file %s has no score' % (
@@ -41,19 +43,20 @@ def VerifyOneTarget(codecs, rate, videofile):
         change_count += 1
   return change_count
 
-def VerifyResults(codecs):
+def VerifyResults(codecs, criterion):
   change_count = 0
   for rate, filename in mpeg_settings.MpegFiles().AllFilesAndRates():
     videofile = encoder.Videofile(filename)
-    change_count += VerifyOneTarget(codecs, rate, videofile)
+    change_count += VerifyOneTarget(codecs, rate, videofile, criterion)
   return change_count
 
 def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('codecs', nargs='*',
                       default=pick_codec.codec_map.keys())
+  parser.add_argument('--criterion', default='psnr')
   args = parser.parse_args()
-  change_count = VerifyResults(args.codecs)
+  change_count = VerifyResults(args.codecs, args.criterion)
   print 'Number of changes: %d' % change_count
   if change_count > 0:
     return 1

--- a/lib/file_codec_unittest.py
+++ b/lib/file_codec_unittest.py
@@ -17,7 +17,9 @@
 import encoder
 import optimizer
 import test_tools
+import time
 import unittest
+import vp8
 
 import file_codec
 
@@ -62,7 +64,7 @@ class TestFileCodec(test_tools.FileUsingCodecTest):
     codec = CopyingCodec()
     my_optimizer = optimizer.Optimizer(codec)
     videofile = test_tools.MakeYuvFileWithOneBlankFrame(
-      'one_black_frame_1024_768_30.yuv')
+        'one_black_frame_1024_768_30.yuv')
     encoding = my_optimizer.BestEncoding(1000, videofile)
     encoding.Execute()
     self.assertTrue(encoding.Result())
@@ -84,6 +86,19 @@ class TestFileCodec(test_tools.FileUsingCodecTest):
     encoding = my_optimizer.BestEncoding(1000, videofile)
     encoding.Execute()
     self.assertFalse(encoding.VerifyEncode())
+
+  def test_VerifyMatroskaFile(self):
+    codec = vp8.Vp8Codec()
+    my_optimizer = optimizer.Optimizer(codec)
+    videofile = test_tools.MakeYuvFileWithOneBlankFrame(
+        'one_black_frame_1024_768_30.yuv')
+    encoding = my_optimizer.BestEncoding(1000, videofile)
+    encoding.Execute()
+    # Matroska files will be identical if generated within the same
+    # clock second. So wait a bit.
+    time.sleep(1)
+    self.assertTrue(encoding.VerifyEncode())
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
It turns out that Matroska files contain some bytes that are generated
at random. This PR changes the VerifyEncoding function to skip those
bytes by using the "vpxdec --md5" tool to verify that there are no changes.

In addition, a flag for showing full encoding results from list_config_results
was added.
