### PR TITLE
Make RT mode encoding for VP8 be stable.

### DIFF
--- a/bin/verify_encoding_is_stable
+++ b/bin/verify_encoding_is_stable
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+# Copyright 2014 Google.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Verifies whether any encodings have changed compared to what's in the
+# database. Intended for use after upgrading software, or for checking
+# whether specific parameters generate stable encodings.
+#
+import argparse
+import sys
+
+import mpeg_settings
+import encoder
+import optimizer
+import pick_codec
+import score_tools
+
+
+def StableEncode(codec_name, configuration, bitrate, videofile_name):
+  codec = pick_codec.PickCodec(codec_name)
+  my_context = encoder.Context(codec, encoder.EncodingDiskCache)
+  my_encoder = encoder.Encoder(my_context,
+                               parameters=encoder.OptionValueSet(
+                                   codec.option_set, configuration))
+  my_encoding = my_encoder.Encoding(bitrate, encoder.Videofile(videofile_name))
+  my_encoding.Recover()
+  if not my_encoding.Result():
+    # For detecting unstable encodings, we may want to try parameters
+    # that have not been run before. So we generate the baseline if missing.
+    print "Producing baseline encode"
+    my_encoding.Execute().Store()
+  return my_encoding.VerifyEncode()
+
+def main():
+  parser = argparse.ArgumentParser('Verifies a specific configuration')
+  parser.add_argument('--codec')
+  parser.add_argument('configuration', help='Parameters to use. '
+                      'Remember to quote the string and put'
+                      '"--" in the command line before it if needed.')
+  parser.add_argument('rate')
+  parser.add_argument('videofile')
+
+  args = parser.parse_args()
+  if StableEncode(args.codec, args.configuration, int(args.rate),
+                  args.videofile):
+    print 'Encoding is stable'
+  else:
+    print 'Encoding is NOT stable'
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/bin/verify_hashnames
+++ b/bin/verify_hashnames
@@ -33,8 +33,18 @@ def VerifyHashnames(codecs, remove_offending_encoders):
     filenames = context.cache.AllEncoderFilenames()
     for filename in filenames:
       try:
-        # If we can create an encoder for this filename, it's OK.
-        encoder.Encoder(context, filename=filename)
+        my_encoder = encoder.Encoder(context, filename=filename)
+        if (codec.ConfigurationFixups(my_encoder.parameters)
+            != my_encoder.parameters):
+          print 'Error: Parameter change for codec %s encoder %s' % (
+              codec.name, filename)
+          print 'Old:', my_encoder.parameters.ToString()
+          print ('New: %s'
+                 % codec.ConfigurationFixups(my_encoder.parameters).ToString())
+          if remove_offending_encoders:
+            print 'Deleting encoder %s' % filename
+            context.cache.RemoveEncoder(filename)
+          change_count += 1
       except (encoder.Error, IOError) as error:
         # encoder.Error is raised if there's a checksum change.
         # IOError is raised if the encoder directory is corrupted,
@@ -43,7 +53,7 @@ def VerifyHashnames(codecs, remove_offending_encoders):
             codec.name, filename, error)
         if remove_offending_encoders:
           print 'Deleting encoder %s' % filename
-          codec.cache.RemoveEncoder(filename)
+          context.cache.RemoveEncoder(filename)
         change_count += 1
   return change_count
 

--- a/lib/encoder.py
+++ b/lib/encoder.py
@@ -357,6 +357,7 @@ class Codec(object):
     raise Error("The base codec class can't execute anything")
 
   def VerifyEncode(self, parameters, bitrate, videofile, workdir):
+    """Returns true if a new encode of the file gives exactly the same file."""
     # pylint: disable=W0613, R0201
     raise Error("The base codec class can't verify anything")
 
@@ -440,6 +441,7 @@ class Encoder(object):
       self.parameters, bitrate, videofile, workdir)
 
   def VerifyEncode(self, bitrate, videofile, workdir):
+    """Returns true if a new encode of the file gives exactly the same file."""
     return self.context.codec.VerifyEncode(
       self.parameters, bitrate, videofile, workdir)
 
@@ -550,7 +552,7 @@ class Encoding(object):
         if not variant_encoding.Result():
           result.append(variant_encoding)
           seen.add(params_as_string)
-    
+
     # If none resulted, make 10 attempts to find an untried candidate
     # by making 2 random changes to the configuration.
     if not result:
@@ -588,6 +590,7 @@ class Encoding(object):
     return self
 
   def VerifyEncode(self):
+    """Returns true if a new encode of the file gives exactly the same file."""
     return self.encoder.VerifyEncode(self.bitrate, self.videofile,
                                      self.Workdir())
 

--- a/lib/vp8_unittest.py
+++ b/lib/vp8_unittest.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Unit tests for encoder module."""
 
+import encoder
 import optimizer
 import test_tools
 import unittest
@@ -46,7 +47,29 @@ class TestVp8(test_tools.FileUsingCodecTest):
     codec = vp8.Vp8Codec()
     self.assertEqual('5000', codec.SpeedGroup(5000))
 
+  def test_ConfigurationFixups(self):
+    codec = vp8.Vp8Codec()
+    # Any value but --rt should be ignored.
+    value_set = encoder.OptionValueSet(codec.option_set,
+                                      '--good')
+    value_set_out = codec.ConfigurationFixups(value_set)
+    self.assertFalse(value_set_out.HasValue('cpu-used'))
+    # Missing values should be filled in.
+    value_set = encoder.OptionValueSet(codec.option_set,
+                                      '--rt')
+    value_set_out = codec.ConfigurationFixups(value_set)
+    self.assertEqual('-1', value_set_out.GetValue('cpu-used'))
+    # Positive values should be converted to -1.
+    value_set = encoder.OptionValueSet(codec.option_set,
+                                      '--rt --cpu-used=5')
+    value_set_out = codec.ConfigurationFixups(value_set)
+    self.assertEqual('-1', value_set_out.GetValue('cpu-used'))
+    # Negative values should be untouched.
+    value_set = encoder.OptionValueSet(codec.option_set,
+                                      '--rt --cpu-used=-5')
+    value_set_out = codec.ConfigurationFixups(value_set)
+    self.assertEqual('-5', value_set_out.GetValue('cpu-used'))
+
+
 if __name__ == '__main__':
   unittest.main()
-
-


### PR DESCRIPTION
In mode --rt, and with --cpu-used set to >= 0, the vp8 encoder will
create different files depending on the machine load. Setting --cpu-used
to a negative number alleviates this.

This CL also contains a tool for verifying that a configuration is
stable, as well as a fix to the hashname verification that checks that
the configuration is unchanged by the ConfigurationFixups call.
