### PR TITLE
Add functions for removing parameters when trying new configurations.

### DIFF
--- a/lib/vp8_mpeg.py
+++ b/lib/vp8_mpeg.py
@@ -27,9 +27,9 @@ class Vp8CodecMpegMode(vp8.Vp8Codec):
     super(Vp8CodecMpegMode, self).__init__(name)
     # Set the parts that are different from the VP8 codec.
     self.option_set = encoder.OptionSet(
-      encoder.IntegerOption('fixed-q', 0, 63),
-      encoder.IntegerOption('gold-q', 0, 63),
-      encoder.IntegerOption('key-q', 0, 63),
+      encoder.IntegerOption('fixed-q', 0, 63).Mandatory(),
+      encoder.IntegerOption('gold-q', 0, 63).Mandatory(),
+      encoder.IntegerOption('key-q', 0, 63).Mandatory(),
       encoder.ChoiceOption(['good', 'best', 'rt']),
     )
     # The start encoder is exactly the same as for VP8,

--- a/lib/vp8_mpeg_1d.py
+++ b/lib/vp8_mpeg_1d.py
@@ -28,7 +28,7 @@ class Vp8CodecMpeg1dMode(vp8_mpeg.Vp8CodecMpegMode):
     super(Vp8CodecMpeg1dMode, self).__init__(name)
     # Set the parts that are different from the VP8 MPEG codec.
     self.option_set = encoder.OptionSet(
-      encoder.IntegerOption('key-q', 0, 63),
+      encoder.IntegerOption('key-q', 0, 63).Mandatory(),
       encoder.DummyOption('fixed-q'),
       encoder.DummyOption('gold-q'),
     )

--- a/lib/vp9.py
+++ b/lib/vp9.py
@@ -29,7 +29,7 @@ class Vp9Codec(file_codec.FileCodec):
     self.option_set = encoder.OptionSet(
       encoder.IntegerOption('cpu-used', 0, 16),
       # The "best" option gives encodes that are too slow to be useful.
-      encoder.ChoiceOption(['good', 'rt']),
+      encoder.ChoiceOption(['good', 'rt']).Mandatory(),
     )
 
   def StartEncoder(self, context):


### PR DESCRIPTION
This change makes the optimizer aggressively remove parameters, and gives
slightly higher scores (0.000001 dB per parameter) for shorter parameter
lists, leading the optimizer to prefer them.

It adds a function for marking parameters as mandatory, since some codecs
function very badly with all parameters removed.

Addresses #4 .