### PR TITLE
Adding X264 baseline codec.

### DIFF
--- a/bin/generate_pages
+++ b/bin/generate_pages
@@ -21,12 +21,11 @@ if [ ! -d $WORKDIR/website/results/generated ]; then
   mkdir $WORKDIR/website/results/generated
 fi
 
-codecs="x264 vp8 vp9 h263"
-
 function list_one_criterion {
   criterion=$1
-  for codec1 in $codecs; do
-    for codec2 in $codecs; do
+  shift
+  for codec1 in $@; do
+    for codec2 in $@; do
       if [ $codec1 != $codec2 ]; then
         echo "Generating $codec1 vs $codec2 criterion $criterion"
         compare_html --criterion $criterion $codec1 $codec2 \
@@ -40,12 +39,12 @@ function list_one_criterion {
   write_cross_performance_tables --criterion $criterion vp8 vp9 x264 h263 \
       > website/results/generated/toplevel-$criterion.json
   write_cross_performance_tables --new_style \
-      --criterion $criterion vp8 vp9 x264 h263 \
+      --criterion $criterion $@ \
       > website/results/generated/toplevel-$criterion-new.json
 
 }
 
-list_one_criterion psnr
-list_one_criterion rt
+list_one_criterion psnr x264 x264_base vp8 vp9
+list_one_criterion rt x264 x264_base vp8 vp9
 
 chmod -R a+rX website/results/generated

--- a/lib/encoder.py
+++ b/lib/encoder.py
@@ -151,6 +151,14 @@ class OptionSet(object):
   def RegisterOption(self, option):
     self.options[option.name] = option
 
+  def LockOption(self, name, value):
+    if not name in self.options:
+      raise Error('No such option name: %s' % name)
+    if not value in self.options[name].values:
+      raise Error('No such option value for %s: %s' % (name, value))
+    self.options[name].values = frozenset([value])
+    self.options[name].Mandatory()
+
   def Option(self, name):
     return self.options[name]
 

--- a/lib/encoder_unittest.py
+++ b/lib/encoder_unittest.py
@@ -130,6 +130,16 @@ class TestOptionSet(unittest.TestCase):
     self.assertTrue(opts.HasOption('foo'))
     self.assertTrue(opts.Option('foo'))
 
+  def test_LockOption(self):
+    opts = encoder.OptionSet(encoder.Option('foo', ['value1', 'value2']))
+    self.assertEqual(2, len(opts.Option('foo').values))
+    self.assertTrue(opts.Option('foo').CanChange())
+    opts.LockOption('foo', 'value1')
+    self.assertTrue(opts.Option('foo').mandatory)
+    print opts.Option('foo').values
+    self.assertEqual(1, len(opts.Option('foo').values))
+    self.assertFalse(opts.Option('foo').CanChange())
+
   def test_FindFlagOption(self):
     opts = encoder.OptionSet(encoder.ChoiceOption(['foo', 'bar']))
     self.assertIsNone(opts.FindFlagOption('baz'))

--- a/lib/pick_codec.py
+++ b/lib/pick_codec.py
@@ -23,6 +23,7 @@ import vp8_mpeg_1d
 import vp9
 import ffmpeg
 import x264
+import x264_baseline
 
 class CodecInfo(object):
   def __init__(self, constructor, shortname, longname):
@@ -42,6 +43,8 @@ codec_map = {
   'h261': CodecInfo(h261.H261Codec, 'H261', 'H.261'),
   'h263': CodecInfo(h263.H263Codec, 'H263', 'H.263'),
   'x264': CodecInfo(x264.X264Codec, 'H264', 'H.264 - x264 implementation'),
+  'x264_base': CodecInfo(x264_baseline.X264BaselineCodec, 'H264-BL',
+                         'H264 Baseline - x264 implementation')
 }
 
 def PickCodec(name):

--- a/lib/x264_baseline.py
+++ b/lib/x264_baseline.py
@@ -1,0 +1,32 @@
+# Copyright 2015 Google.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""X264 baseline codec definition.
+
+This file defines how to run encode and decode for the x264 implementation
+of H.264 using the Baseline profile.
+"""
+import encoder
+import x264
+
+
+class X264BaselineCodec(x264.X264Codec):
+  def __init__(self, name='x264-base', formatter=None):
+    super(X264BaselineCodec, self).__init__(name, formatter)
+    self.option_set.LockOption('profile', 'baseline')
+
+  def StartEncoder(self, context):
+    return encoder.Encoder(context, encoder.OptionValueSet(
+      self.option_set,
+      '--profile baseline --preset slow --tune psnr',
+      formatter=self.option_formatter))

--- a/lib/x264_unittest.py
+++ b/lib/x264_unittest.py
@@ -18,15 +18,15 @@ import encoder
 import optimizer
 import unittest
 import test_tools
-import x264
+import x264_baseline
 
-class TestX264(test_tools.FileUsingCodecTest):
+class TestX264Baseline(test_tools.FileUsingCodecTest):
   def test_Init(self):
-    codec = x264.X264Codec()
-    self.assertEqual(codec.name, 'x264')
+    codec = x264_baseline.X264BaselineCodec()
+    self.assertEqual(codec.name, 'x264-base')
 
   def test_OneBlackFrame(self):
-    codec = x264.X264Codec()
+    codec = x264_baseline.X264BaselineCodec()
     my_optimizer = optimizer.Optimizer(codec)
     videofile = test_tools.MakeYuvFileWithOneBlankFrame(
         'one_black_frame_1024_768_30.yuv')
@@ -35,25 +35,15 @@ class TestX264(test_tools.FileUsingCodecTest):
     # Most codecs should be good at this.
     self.assertLess(40.0, my_optimizer.Score(encoding))
 
-  def test_VbvMaxrateFlag(self):
-    codec = x264.X264Codec()
+  def test_HasBaselineFlag(self):
+    codec = x264_baseline.X264BaselineCodec()
     context = encoder.Context(codec)
     my_encoder = codec.StartEncoder(context)
     videofile = test_tools.MakeYuvFileWithOneBlankFrame(
         'one_black_frame_1024_768_30.yuv')
     encoding = my_encoder.Encoding(1000, videofile)
-    # The start encoder should have no bitrate.
     commandline = encoding.EncodeCommandLine()
-    self.assertNotRegexpMatches(commandline, 'vbv-maxrate')
-    # Add in the use-vbv-maxrate parameter.
-    new_encoder = encoder.Encoder(context,
-        my_encoder.parameters.ChangeValue('use-vbv-maxrate', 'use-vbv-maxrate'))
-    encoding = new_encoder.Encoding(1000, videofile)
-    commandline = encoding.EncodeCommandLine()
-    # vbv-maxrate should occur, but not use-vbv-maxrate.
-    self.assertRegexpMatches(commandline, '--vbv-maxrate 1000 ')
-    self.assertNotRegexpMatches(commandline, 'use-vbv-maxrate')
-
+    self.assertRegexpMatches(commandline, '--profile baseline ')
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This adds measurements for the "baseline" configuration of H.264
to the tables. It also separates the list of codecs for the RT
mode and the PSNR mode comparision, so that we can make them
different when we need to.