### PR TITLE
Changes the storage format for results from Python literals to JSON.

### DIFF
--- a/bin/force_run_config
+++ b/bin/force_run_config
@@ -27,9 +27,9 @@ import pick_codec
 def ExecuteConfig(codec_name, config_string=None, config_id=None):
   codec = pick_codec.PickCodec(codec_name)
   context = encoder.Context(codec, cache_class=encoder.EncodingDiskCache)
-  if config_string and config_id:
+  if config_string is not None and config_id is not None:
     raise encoder.Error('Cannot have both an ID and a configuration string')
-  if config_string:
+  if config_string is not None:
     my_encoder = encoder.Encoder(
         context,
         encoder.OptionValueSet(codec.option_set,

--- a/lib/encoder.py
+++ b/lib/encoder.py
@@ -33,7 +33,9 @@ os.getenv(CODEC_TOOLPATH) gives the directory of encoder/decoder tools.
 """
 
 import ast
+import exceptions
 import glob
+import json
 import md5
 import os
 import random
@@ -795,7 +797,7 @@ class EncodingDiskCache(object):
       return
     videoname = encoding.videofile.basename
     with open('%s/%s.result' % (dirname, videoname), 'w') as resultfile:
-      resultfile.write(str(encoding.result))
+      json.dump(encoding.result, resultfile, indent=2)
 
   def ReadEncodingResult(self, encoding, scoredir=None):
     """Reads an encoding result back from storage, if present.
@@ -813,9 +815,15 @@ class EncodingDiskCache(object):
       with open(filename, 'r') as resultfile:
         stringbuffer = resultfile.read()
         try:
-          return ast.literal_eval(stringbuffer)
+          return json.loads(stringbuffer)
+        except exceptions.ValueError:
+          try:
+            return ast.literal_eval(stringbuffer)
+          except:
+            raise Error('Unexpected AST error: %s, filename was %s' %
+                        (sys.exc_info()[0], filename))
         except:
-          raise Error('Unexpected AST error: %s, filename was %s' %
+          raise Error('Unexpected JSON error: %s, filename was %s' %
                       (sys.exc_info()[0], filename))
     return None
 


### PR DESCRIPTION
This speeds up result parsing considerably, as well as using a more
standard format for storage - important when one shares results.

Also moves a requirement on enoding time due to testing on a slow
computer.