### PR TITLE
Adding two HEVC codecs, reporting on one of them.

### DIFF
--- a/bin/generate_pages
+++ b/bin/generate_pages
@@ -45,7 +45,7 @@ function list_one_criterion {
 
 }
 
-list_one_criterion psnr x264 x264_base vp8 vp9
+list_one_criterion psnr x264 x264_base vp8 vp9 x265
 list_one_criterion rt x264_rt x264_base vp8 vp9
 
 if [ ! -d website/_data ]; then

--- a/bin/show_versions
+++ b/bin/show_versions
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Copyright 2015 Google.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Tool to show versions of stuff we're using.
+# Also serves as a repository of useful Git command lines
+# for inquiring into same.
+#
+echo 'Toolset'
+if git diff-index --quiet HEAD compile_tools.sh; then
+  echo 'compile_tools is NOT locally modified'
+else
+  echo 'compile_tools is locally modified'
+fi
+git log --oneline -1 compile_tools.sh
+git log --format='%h %ad %s' -1 compile_tools.sh
+git log --format='%H' -1 compile_tools.sh
+echo 'Last 4 overall checkouts'
+git log --format='%h %ad %s' -4

--- a/compile_tools.sh
+++ b/compile_tools.sh
@@ -43,64 +43,137 @@ gcc -o $TOOLDIR/psnr src/psnr.c -lm
 # Build third party source
 cd $WORKDIR/third_party
 
-# Build the vpxenc and vpxdec binaries
-if [ ! -d libvpx ]; then
-  git clone http://git.chromium.org/webm/libvpx.git
+# The program continues after the function declarations.
+
+build_vpxenc() {
+  # Build the vpxenc and vpxdec binaries
+  if [ ! -d libvpx ]; then
+    git clone http://git.chromium.org/webm/libvpx.git
+  fi
+  cd libvpx
+  # Ensure we check out exactly a consistent version.
+  git checkout -f master
+  #git checkout v1.3.0
+  # Check out the Oct 20 2014 version of libvpx.
+  git checkout 9c98fb2bab6125a0614576bf7635981163b1cc79
+  ./configure
+  # Leftovers from previous compilations may be troublesome.
+  make clean
+  make
+  cp vpxenc $TOOLDIR
+  cp vpxdec $TOOLDIR
+
+  # Build a patched version of vpxenc that supports setting
+  # the q-value for key-frames, golden frames and alt-frames separately
+  # from the generic fixed q value that is used for all other frames.
+  patch -p1 < ../vp8_fixed_q.patch
+  make
+  cp vpxenc $TOOLDIR/vpxenc-mpeg
+}
+
+build_x264() {
+  # Build the x264 binary.
+  if [ ! -d x264 ]; then
+    git clone git://git.videolan.org/x264.git
+  fi
+  cd x264
+  # This version of x264 is chosen because the next step requires yasm 1.2.
+  # Was: git checkout d967c09
+  # git checkout 8a9608
+  # Latest version as of Oct 20 2014 - version above crashes on trusty.
+  git checkout dd79a61
+
+  ./configure
+  make x264
+  cp x264 $TOOLDIR
+}
+
+build_ffmpeg() {
+  # Build the ffmpeg binary.
+  if [ ! -d ffmpeg ]; then
+    git clone git://source.ffmpeg.org/ffmpeg.git ffmpeg
+  fi
+  cd ffmpeg
+  # A known working 2012 version (without H265 support)
+  # git checkout ae04493
+  # A Feb 2015 version
+  # git checkout 60bb893
+  # Checking out a named version.
+  git checkout n2.5.3
+  ./configure
+  make clean
+  make ffmpeg
+  cp ffmpeg $TOOLDIR
+  make ffprobe
+  cp ffprobe $TOOLDIR
+}
+
+build_x265() {
+  # Build the x265 binary.
+  if [ ! -d x265 ]; then
+    hg clone https://bitbucket.org/multicoreware/x265
+  fi
+  cd x265/build/linux
+  hg update 1.5
+  rm -f CMakeCache.txt
+  cmake ../../source
+  make
+  cp x265 $TOOLDIR
+}
+
+build_hevc_hm() {
+
+  # Build the HEVC HM
+  if [ ! -d jctvc-hm ]; then
+    mkdir jtcvc-hm
+  fi
+  HM_VERSION=HM-16.3
+  cd jctvc-hm
+  svn checkout svn://hevc.kw.bbc.co.uk/svn/jctvc-hm/tags/$HM_VERSION
+  pushd $HM_VERSION/build/linux
+  make
+  popd
+  cp $HM_VERSION/bin/TAppDecoderStatic $TOOLDIR
+  cp $HM_VERSION/bin/TAppEncoderStatic $TOOLDIR
+  # Encoding with HM is impossible without config files.
+  cp $HM_VERSION/cfg/encoder_randomaccess_main.cfg $TOOLDIR/hevc_ra_main.cfg
+}
+
+# Selecting which components to build.
+build_func () {
+while [ "$1" != "" ]; do
+  cd $WORKDIR/third_party
+  case $1 in
+    vpxenc)
+      build_vpxenc
+      ;;
+    x264)
+      build_x264
+      ;;
+    ffmpeg)
+      build_ffmpeg
+      ;;
+    x265)
+      build_x265
+      ;;
+    hevc)
+      build_hevc_hm
+      ;;
+    *)
+      echo "Can't do $1"
+      exit 1
+  esac
+  shift
+done
+}
+
+# The default is to build everything.
+if [ "x$@" == "x" ]; then
+  echo "Building everything"
+  build_func vpxenc x264 ffmpeg x265 hevc
+else
+  build_func $@
 fi
-cd libvpx
-# Ensure we check out exactly a consistent version.
-git checkout -f master
-#git checkout v1.3.0
-# Check out the Oct 20 2014 version of libvpx.
-git checkout 9c98fb2bab6125a0614576bf7635981163b1cc79
-./configure
-# Leftovers from previous compilations may be troublesome.
-make clean
-# There's something wrong in the make for libvpx at this version.
-# Ignore the result code from make. We'll bail if vpxenc and vpxdec
-# were not built.
-make || echo "Something went wrong building libvpx, continuing"
-cp vpxenc $TOOLDIR
-cp vpxdec $TOOLDIR
 
-# Build a patched version of vpxenc that supports setting
-# the q-value for key-frames, golden frames and alt-frames separately
-# from the generic fixed q value that is used for all other frames.
-patch -p1 < ../vp8_fixed_q.patch
-make
-cp vpxenc $TOOLDIR/vpxenc-mpeg
-
-cd ..
-
-
-# Build the x264 binary.
-if [ ! -d x264 ]; then
-  git clone git://git.videolan.org/x264.git
-fi
-cd x264
-# This version of x264 is chosen because the next step requires yasm 1.2.
-# Was: git checkout d967c09
-# git checkout 8a9608
-# Latest version as of Oct 20 2014 - version above crashes on trusty.
-git checkout dd79a61
-
-./configure
-make x264
-cp x264 $TOOLDIR
-cd ..
-
-# Build the ffmpeg binary.
-if [ ! -d ffmpeg ]; then
-  git clone git://source.ffmpeg.org/ffmpeg.git ffmpeg
-fi
-cd ffmpeg
-git checkout ae04493
-./configure
-make ffmpeg
-cp ffmpeg $TOOLDIR
-make ffprobe
-cp ffprobe $TOOLDIR
-cd ..
-
-
-
+echo "All done"
+exit 0

--- a/install_software.sh
+++ b/install_software.sh
@@ -20,11 +20,10 @@
 #
 set -e
 
-# Requirements for compiling libvpx.
-sudo apt-get install yasm
+# Requirements for compiling various packages and scripts.
+sudo apt-get install yasm mkvtoolnix mercurial cmake cmake-curses-gui \
+  build-essential yasm
 
-# More tools called by the scripts
-sudo apt-get install mkvtoolnix
 # Install prerequisites for running Jekyll as a web server
 sudo apt-get install ruby1.9.1-dev
 sudo apt-get install nodejs
@@ -39,5 +38,3 @@ sudo gem install jekyll -v 1.5.1
 ./compile_tools.sh
 
 echo "All software installed"
-
-

--- a/lib/encoder.py
+++ b/lib/encoder.py
@@ -373,10 +373,12 @@ class Videofile(object):
     encodedframesize = encodedsize / framecount
     return encodedframesize * self.framerate * 8 / 1000
 
-  def ClipTime(self):
+  def FrameCount(self):
     framesize = self.width * self.height * 3 / 2
-    framecount = os.path.getsize(self.filename) / framesize
-    return float(framecount) / self.framerate
+    return os.path.getsize(self.filename) / framesize
+
+  def ClipTime(self):
+    return float(self.FrameCount()) / self.framerate
 
 
 class Codec(object):

--- a/lib/ffmpeg.py
+++ b/lib/ffmpeg.py
@@ -41,10 +41,11 @@ class FfmpegCodec(file_codec.FileCodec):
 
   def EncodeCommandLine(self, parameters, bitrate, videofile, encodedfile):
     commandline = (
-      '%s -loglevel warning %s -s %dx%d -i %s -codec:v %s -b:v %dk -y %s' % (
+      '%s -loglevel warning -s %dx%d -i %s -codec:v %s %s -b:v %dk -y %s' % (
         encoder.Tool('ffmpeg'),
-        parameters.ToString(), videofile.width, videofile.height,
+        videofile.width, videofile.height,
         videofile.filename, self.codecname,
+        parameters.ToString(),
         bitrate, encodedfile))
     return commandline
 

--- a/lib/hevc_jm.py
+++ b/lib/hevc_jm.py
@@ -1,0 +1,65 @@
+# Copyright 2015 Google.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Framework for specifying encoders from ffmpeg.
+
+This uses ffmpeg for encoding and decoding.
+The default FFMPEG encoder uses mpeg4, so that we can see if it's roughly
+compatible with the vpxenc-produced qualities.
+"""
+import ast
+import os
+import subprocess
+
+import encoder
+import file_codec
+
+
+class HevcCodec(file_codec.FileCodec):
+
+  def __init__(self,
+               name='hevc',
+               formatter=None):
+    self.name = name
+    self.codecname = 'hevc'
+    self.extension = 'hevc'
+    super(HevcCodec, self).__init__(
+      name,
+      formatter=formatter)
+
+  def StartEncoder(self, context):
+    return encoder.Encoder(context, encoder.OptionValueSet(self.option_set, ''))
+
+  def EncodeCommandLine(self, parameters, bitrate, videofile, encodedfile):
+    commandline = (
+        '%s --SourceWidth=%d ---SourceHeight=%d '
+        '-c %s '
+        '--FrameRate=%d --InputFile=%s '
+        '--FramesToBeEncoded=%d '
+        '--IntraPeriod=-1 '
+        '%s --TargetBitrate=%d --BitstreamFile=%s' % (
+            encoder.Tool('TAppEncoderStatic'),
+            videofile.width, videofile.height,
+            encoder.Tool('hevc_ra_main.cfg'),  # Configuration file
+            videofile.framerate,
+            videofile.filename,
+            videofile.FrameCount(),
+            parameters.ToString(),
+            bitrate, encodedfile))
+    return commandline
+
+  def DecodeCommandLine(self, videofile, encodedfile, yuvfile):
+    commandline = "%s --BitstreamFile=%s --ReconFile=%s" % (
+        encoder.Tool('TAppDecoderStatic'),
+        encodedfile, yuvfile)
+    return commandline

--- a/lib/hevc_jm_unittest.py
+++ b/lib/hevc_jm_unittest.py
@@ -18,15 +18,16 @@ import encoder
 import optimizer
 import unittest
 import test_tools
-import x264
+import hevc_jm
 
-class TestX264(test_tools.FileUsingCodecTest):
+
+class TestHevc(test_tools.FileUsingCodecTest):
   def test_Init(self):
-    codec = x264.X264Codec()
-    self.assertEqual(codec.name, 'x264')
+    codec = hevc_jm.HevcCodec()
+    self.assertEqual(codec.name, 'hevc')
 
   def test_OneBlackFrame(self):
-    codec = x264.X264Codec()
+    codec = hevc_jm.HevcCodec()
     my_optimizer = optimizer.Optimizer(codec)
     videofile = test_tools.MakeYuvFileWithOneBlankFrame(
         'one_black_frame_1024_768_30.yuv')
@@ -35,34 +36,15 @@ class TestX264(test_tools.FileUsingCodecTest):
     # Most codecs should be good at this.
     self.assertLess(40.0, my_optimizer.Score(encoding))
 
-  def test_TenBlackFrames(self):
-    codec = x264.X264Codec()
+  def test_MoreBlackFrames(self):
+    codec = hevc_jm.HevcCodec()
     my_optimizer = optimizer.Optimizer(codec)
     videofile = test_tools.MakeYuvFileWithBlankFrames(
-        'ten_black_frames_1024_768_30.yuv', 10)
+        'more_black_frames_1024_768_30.yuv', 8)
     encoding = my_optimizer.BestEncoding(1000, videofile)
     encoding.Execute()
     # Most codecs should be good at this.
     self.assertLess(40.0, my_optimizer.Score(encoding))
-
-  def test_VbvMaxrateFlag(self):
-    codec = x264.X264Codec()
-    context = encoder.Context(codec)
-    my_encoder = codec.StartEncoder(context)
-    videofile = test_tools.MakeYuvFileWithOneBlankFrame(
-        'one_black_frame_1024_768_30.yuv')
-    encoding = my_encoder.Encoding(1000, videofile)
-    # The start encoder should have no bitrate.
-    commandline = encoding.EncodeCommandLine()
-    self.assertNotRegexpMatches(commandline, 'vbv-maxrate')
-    # Add in the use-vbv-maxrate parameter.
-    new_encoder = encoder.Encoder(context,
-        my_encoder.parameters.ChangeValue('use-vbv-maxrate', 'use-vbv-maxrate'))
-    encoding = new_encoder.Encoding(1000, videofile)
-    commandline = encoding.EncodeCommandLine()
-    # vbv-maxrate should occur, but not use-vbv-maxrate.
-    self.assertRegexpMatches(commandline, '--vbv-maxrate 1000 ')
-    self.assertNotRegexpMatches(commandline, 'use-vbv-maxrate')
 
 
 if __name__ == '__main__':

--- a/lib/mjpeg.py
+++ b/lib/mjpeg.py
@@ -24,8 +24,8 @@ class MotionJpegCodec(ffmpeg.FfmpegCodec):
     self.codecname = 'mjpeg'
     self.extension = 'mjpeg'
     self.option_set = encoder.OptionSet(
-      encoder.IntegerOption('qmin', 0, 1),
-      encoder.IntegerOption('qmax', 0, 1),
+      encoder.IntegerOption('qmin', 1, 69),
+      encoder.IntegerOption('qmax', 2, 1024),
     )
 
   def StartEncoder(self, context):

--- a/lib/mjpeg_unittest.py
+++ b/lib/mjpeg_unittest.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Unit tests for Motion JPEG encoder module."""
 
+import encoder
 import optimizer
 import unittest
 import test_tools
@@ -32,7 +33,17 @@ class TestMotionJpegCodec(test_tools.FileUsingCodecTest):
     encoding.Execute()
     self.assertLess(50.0, my_optimizer.Score(encoding))
 
+  def test_ParametersSet(self):
+    codec = mjpeg.MotionJpegCodec()
+    my_optimizer = optimizer.Optimizer(codec)
+    videofile = test_tools.MakeYuvFileWithOneBlankFrame(
+        'one_black_frame_1024_768_30.yuv')
+    my_encoder = encoder.Encoder(my_optimizer.context,
+        encoder.OptionValueSet(codec.option_set, '-qmin 1 -qmax 1',
+                               formatter=codec.option_formatter))
+    encoding = my_encoder.Encoding(5000, videofile)
+    encoding.Execute()
+    self.assertLess(50.0, my_optimizer.Score(encoding))
+
 if __name__ == '__main__':
   unittest.main()
-
-

--- a/lib/pick_codec.py
+++ b/lib/pick_codec.py
@@ -16,6 +16,7 @@
 import encoder
 import h261
 import h263
+import hevc_jm
 import mjpeg
 import vp8
 import vp8_mpeg
@@ -25,6 +26,7 @@ import ffmpeg
 import x264
 import x264_baseline
 import x264_realtime
+import x265
 
 class CodecInfo(object):
   def __init__(self, constructor, shortname, longname):
@@ -48,7 +50,10 @@ codec_map = {
                          'H264 Baseline - x264 implementation'),
   'x264_rt': CodecInfo(x264_realtime.X264RealtimeCodec, 'H264-RT',
                        'H264 - x264 implementation, realtime settings'),
+  'x265': CodecInfo(x265.X265Codec, 'H265', 'HEVC - x265 implementation'),
+  'hevc': CodecInfo(hevc_jm.HevcCodec, 'HEVC', 'HEVC - JM implementation'),
 }
+
 
 def PickCodec(name):
   if name is None:
@@ -56,6 +61,7 @@ def PickCodec(name):
   if name in codec_map:
     return codec_map[name].constructor()
   raise encoder.Error('Unrecognized codec name %s' % name)
+
 
 def ShortName(name):
   """Return a pretty but short name for the codec."""
@@ -68,6 +74,3 @@ def LongName(name):
   if name in codec_map:
     return codec_map[name].longname
   raise encoder.Error('Unrecognized codec name %s' % name)
-
-
-

--- a/lib/test_tools.py
+++ b/lib/test_tools.py
@@ -30,16 +30,21 @@ def InitWorkDir():
   os.environ['CODEC_WORKDIR'] = dirname
   return dirname
 
-def MakeYuvFileWithOneBlankFrame(name):
-  """ Make an YUV file with one black frame.
+def MakeYuvFileWithBlankFrames(name, count):
+  """ Make an YUV file with one or more blank frames (all zeroes).
   The size of the frame is encoded in the filename."""
   videofile = encoder.Videofile('%s/%s' % (os.getenv('CODEC_WORKDIR'),
                                            name))
   # Frame size in an YUV 4:2:0 file is 1.5 bytes per pixel.
   framesize = videofile.width * videofile.height * 3 / 2
   with open(videofile.filename, 'w') as real_file:
-    real_file.write('\0' * framesize)
+    real_file.write('\0' * framesize * count)
   return videofile
+
+def MakeYuvFileWithOneBlankFrame(name):
+  """ Make an YUV file with one black frame.
+  The size of the frame is encoded in the filename."""
+  return MakeYuvFileWithBlankFrames(name, 1)
 
 def FinishWorkDir(dirname):
   # Verification of validity
@@ -65,9 +70,7 @@ class FileUsingCodecTest(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
     cls._workdir = InitWorkDir()
-  
+
   @classmethod
   def tearDownClass(cls):
     FinishWorkDir(cls._workdir)
-
-

--- a/lib/x265.py
+++ b/lib/x265.py
@@ -1,0 +1,65 @@
+# Copyright 2014 Google.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""X265 codec definitions.
+
+This gives the definitions required to run the x265 implementation of
+the HEVC codec.
+"""
+import encoder
+import ffmpeg
+
+
+class X265Codec(ffmpeg.FfmpegCodec):
+  def __init__(self, name='x265'):
+    # The x265 encoder uses default parameter delimiters, unlike
+    # the ffmpeg family; we inherit the decoding process.
+    super(X265Codec, self).__init__(name,
+                                    formatter=encoder.OptionFormatter())
+    self.extension = 'hevc'
+    self.codecname = 'hevc'
+    self.option_set = encoder.OptionSet()
+
+  def StartEncoder(self, context):
+    return encoder.Encoder(context, encoder.OptionValueSet(self.option_set,
+        ''))
+
+  def ConfigurationFixups(self, config):
+    # No fixups so far.
+    return config
+
+  def EncodeCommandLine(self, parameters, bitrate, videofile, encodedfile):
+    commandline = ('%(x265)s '
+        '--bitrate %(bitrate)d --fps %(framerate)d '
+        '--threads 1 '
+        '--input-res %(width)dx%(height)d '
+        '%(parameters)s '
+        '-o %(outputfile)s %(inputfile)s') % {
+            'x265': encoder.Tool('x265'),
+            'bitrate': bitrate,
+            'framerate': videofile.framerate,
+            'width': videofile.width,
+            'height': videofile.height,
+            'outputfile': encodedfile,
+            'inputfile': videofile.filename,
+            'parameters': parameters.ToString()}
+    return commandline
+
+  def DecodeCommandLine(self, videofile, encodedfile, yuvfile):
+    # Because of a bug in the ffmpeg decoder, we're using JM decoder.
+    # ffmpeg sometimes produces a decoded YUV file slightly shorter
+    # than the expected size.
+    commandline = '%s -b %s -o %s' % (encoder.Tool('TAppDecoderStatic'),
+                                      encodedfile,
+                                      yuvfile)
+    return commandline

--- a/lib/x265_unittest.py
+++ b/lib/x265_unittest.py
@@ -18,15 +18,15 @@ import encoder
 import optimizer
 import unittest
 import test_tools
-import x264
+import x265
 
 class TestX264(test_tools.FileUsingCodecTest):
   def test_Init(self):
-    codec = x264.X264Codec()
-    self.assertEqual(codec.name, 'x264')
+    codec = x265.X265Codec()
+    self.assertEqual(codec.name, 'x265')
 
   def test_OneBlackFrame(self):
-    codec = x264.X264Codec()
+    codec = x265.X265Codec()
     my_optimizer = optimizer.Optimizer(codec)
     videofile = test_tools.MakeYuvFileWithOneBlankFrame(
         'one_black_frame_1024_768_30.yuv')
@@ -36,7 +36,7 @@ class TestX264(test_tools.FileUsingCodecTest):
     self.assertLess(40.0, my_optimizer.Score(encoding))
 
   def test_TenBlackFrames(self):
-    codec = x264.X264Codec()
+    codec = x265.X265Codec()
     my_optimizer = optimizer.Optimizer(codec)
     videofile = test_tools.MakeYuvFileWithBlankFrames(
         'ten_black_frames_1024_768_30.yuv', 10)
@@ -44,25 +44,6 @@ class TestX264(test_tools.FileUsingCodecTest):
     encoding.Execute()
     # Most codecs should be good at this.
     self.assertLess(40.0, my_optimizer.Score(encoding))
-
-  def test_VbvMaxrateFlag(self):
-    codec = x264.X264Codec()
-    context = encoder.Context(codec)
-    my_encoder = codec.StartEncoder(context)
-    videofile = test_tools.MakeYuvFileWithOneBlankFrame(
-        'one_black_frame_1024_768_30.yuv')
-    encoding = my_encoder.Encoding(1000, videofile)
-    # The start encoder should have no bitrate.
-    commandline = encoding.EncodeCommandLine()
-    self.assertNotRegexpMatches(commandline, 'vbv-maxrate')
-    # Add in the use-vbv-maxrate parameter.
-    new_encoder = encoder.Encoder(context,
-        my_encoder.parameters.ChangeValue('use-vbv-maxrate', 'use-vbv-maxrate'))
-    encoding = new_encoder.Encoding(1000, videofile)
-    commandline = encoding.EncodeCommandLine()
-    # vbv-maxrate should occur, but not use-vbv-maxrate.
-    self.assertRegexpMatches(commandline, '--vbv-maxrate 1000 ')
-    self.assertNotRegexpMatches(commandline, 'use-vbv-maxrate')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds the X265 and HEVC implementations of the HEVC (H.265) codec.

Neither codec has parameters that can vary yet.
Reporting exposes only the X265 codec so far.

Note - there is a bug in ffmpeg's decoding of HEVC files that sometimes
produces the wrong number of frames - as a stopgap measure, the decoder
from the HEVC Reference Model is used.