### PR TITLE
Multiple filesets support.

### DIFF
--- a/.pylint.rc
+++ b/.pylint.rc
@@ -45,7 +45,7 @@ load-plugins=
 # that would be nice to have but not universally done are suppressed.
 # TODO(hta): Split this list into permanent and should-be-fixed categories.
 disable=similarities, missing-docstring, locally-disabled, fixme,
-  too-few-public-methods
+  too-few-public-methods, bad-continuation
 
 [REPORTS]
 

--- a/bin/compare_codecs
+++ b/bin/compare_codecs
@@ -23,8 +23,8 @@
 import argparse
 import sys
 
-import mpeg_settings
 import encoder
+import fileset_picker
 import optimizer
 import pick_codec
 import score_tools
@@ -44,13 +44,13 @@ def ListOneTarget(codecs, scorer_function, rate, videofile, do_score):
                                 my_optimizer.Score(bestsofar)),
   print ''
 
-def ListResults(codecs, scorer, do_score):
+def ListResults(codecs, scorer, fileset, do_score):
   scorer_function = score_tools.PickScorer(scorer)
   print '%-28s %5s' % ('File', 'Rate'),
   for codec in codecs:
     print '%17s' % pick_codec.ShortName(codec),
   print
-  for rate, filename in mpeg_settings.MpegFiles().AllFilesAndRates():
+  for rate, filename in fileset.AllFilesAndRates():
     videofile = encoder.Videofile(filename)
     ListOneTarget(codecs, scorer_function, rate, videofile, do_score)
 
@@ -58,10 +58,12 @@ def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('--score', action='store_true', default=False)
   parser.add_argument('--criterion', default='psnr')
+  parser.add_argument('--fileset', default='mpeg_video')
   parser.add_argument('codecs', nargs='*',
                       default=pick_codec.AllCodecNames())
   args = parser.parse_args()
-  ListResults(args.codecs, args.criterion, args.score)
+  fileset = fileset_picker.PickFileset(args.fileset)
+  ListResults(args.codecs, args.criterion, fileset, args.score)
   return 0
 
 if __name__ == '__main__':

--- a/bin/list_best_results
+++ b/bin/list_best_results
@@ -22,6 +22,7 @@ import argparse
 import sys
 
 import encoder
+import fileset_picker
 import mpeg_settings
 import optimizer
 import pick_codec
@@ -32,6 +33,7 @@ def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('videofile', nargs='?')
   parser.add_argument('--codec')
+  parser.add_argument('--fileset', default='mpeg_video')
   parser.add_argument('--component')
   parser.add_argument('--single_config', action='store_true')
   parser.add_argument('--criterion', default='psnr')
@@ -41,7 +43,7 @@ def main():
   codec = pick_codec.PickCodec(args.codec)
   my_optimizer = optimizer.Optimizer(codec,
       score_function=score_tools.PickScorer(args.criterion),
-      file_set=mpeg_settings.MpegFiles())
+      file_set=fileset_picker.PickFileset(args.fileset))
   if args.videofile:
     videofiles = [args.videofile]
   else:

--- a/lib/fileset_picker.py
+++ b/lib/fileset_picker.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+# Copyright 2015 Google.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import encoder
+import glob
+import mpeg_settings
+import optimizer
+import os
+
+
+class Error(Exception):
+  pass
+
+
+def ChooseRates(width, framerate):
+  if width >= 1920 and framerate >= 50:
+    return [3000, 4500, 7000, 10000]
+  if width >= 1920 and framerate >= 24:
+    return [1600, 2500, 4000, 6000]
+  if width >= 832 and framerate >= 50:
+    return [512, 768, 1200, 2000]
+  if width >= 416:
+    return [384, 512, 850, 1500]
+  raise Error('Unhandled width/framerate combo: w=%d rate=%d' %
+              (width, framerate))
+
+
+def GenerateFilesetFromDirectory(name):
+  """Returns a FileAndRateSet containing all the YUV files in the directory."""
+  yuvfiles = glob.glob(os.path.join(os.getenv('WORKDIR'),
+                                    'video', name, '*.yuv'))
+  my_set = optimizer.FileAndRateSet()
+  for yuvfile in yuvfiles:
+    videofile = encoder.Videofile(yuvfile)
+    my_set.AddFilesAndRates([videofile.filename],
+                            ChooseRates(videofile.width, videofile.framerate))
+  return my_set
+
+
+def PickFileset(name):
+  if name == 'mpeg_video':
+    return mpeg_settings.MpegFiles()
+  elif os.path.isdir(os.path.join('video', name)):
+    return GenerateFilesetFromDirectory(name)
+  else:
+    raise Error('Fileset %s not found' % name)

--- a/lib/fileset_picker_unittest.py
+++ b/lib/fileset_picker_unittest.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+# Copyright 2015 Google.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Unit tests for the fileset picker. """
+import os
+import test_tools
+import unittest
+
+import fileset_picker
+
+
+class TestFilesetPicker(unittest.TestCase):
+  def testPickMpegFileset(self):
+    fileset = fileset_picker.PickFileset('mpeg_video')
+    self.assertEquals(44, len(fileset.AllFilesAndRates()))
+
+  def testPickNonexistentFileset(self):
+    with self.assertRaises(fileset_picker.Error):
+      fileset_picker.PickFileset('no_such_directory')
+
+
+class TestFilesetPickerWithLocalFiles(test_tools.FileUsingCodecTest):
+  def testPickLocalVideoDirectory(self):
+    os.mkdir(os.path.join(os.getenv('WORKDIR'), 'video'))
+    os.mkdir(os.path.join(os.getenv('WORKDIR'), 'video', 'local'))
+    test_tools.MakeYuvFileWithOneBlankFrame(
+        'video/local/one_black_frame_1024_768_30.yuv')
+    fileset = fileset_picker.PickFileset('local')
+    self.assertEquals(4, len(fileset.AllFilesAndRates()))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/lib/test_tools.py
+++ b/lib/test_tools.py
@@ -28,6 +28,7 @@ def InitWorkDir():
   if not os.path.isdir(dirname):
     os.mkdir(dirname)
   os.environ['CODEC_WORKDIR'] = dirname
+  os.environ['WORKDIR'] = dirname
   return dirname
 
 def MakeYuvFileWithBlankFrames(name, count):

--- a/website/contributing/index.md
+++ b/website/contributing/index.md
@@ -25,7 +25,7 @@ The steps for running a comparision yourself are:
     Contributions to make it work on other systems are welcome!
 
   * Go to the main directory and run the `install_prerequisites.sh` script.
-    Run the `FIXME` script to install your test video clips.
+    Run the `video/get-stuff` script to install some test video clips.
 
   * Source the `init.sh` file. This sets your path and environment variables
     correctly.
@@ -43,12 +43,17 @@ In order to run a specific comparision:
 
   * compare_codecs --score <codec1> <codec2>
 
-  * compare_html <codec1> <codec2> > <html file of your choice>
-
 This may be appropriate after you have done specific tweaks, added a codec,
 done additional runs with new parameters, or just want to re-run.
 
 Use `list_codecs` to get a list of the codecs available.
+
+The default fileset is the MPEG clip set (mpeg_video), which is not publicly
+available. In order to run with the webm clip set (useful for evaluating
+videoconferencing scenarios), give the scripts the `--fileset webm` argument.
+
+If you wish to use your own clips, make a subdirectory called "local" under the
+"video" directory, and use the `--fileset local` argument.
 
 ### Using Others' Encoding Data
 


### PR DESCRIPTION
This adds a picker for filesets, with MPEG being treated specially,
and others having rates picked from a decision tree.
Filesets are directories under "video".

Also suppressed a new warning that appeared with pylint 1.4.1.