### PR TITLE
Add a "passes" parameter to the VP9 encoder

### DIFF
--- a/bin/rewrite_ast_as_json
+++ b/bin/rewrite_ast_as_json
@@ -27,14 +27,13 @@ class Error(Exception):
   pass
 
 
-def ReadAndPossiblyRewriteEncodingResult(filename):
+def ReadAndMaybeRewriteResult(filename):
   if os.path.isfile(filename):
     rewrite = False
     with open(filename, 'r') as resultfile:
       stringbuffer = resultfile.read()
       try:
         result = json.loads(stringbuffer)
-        print 'Json finished'
         if result:
           return 'OK'
       except exceptions.ValueError:
@@ -65,11 +64,11 @@ def main():
   counter = collections.Counter()
   overall_counter = 0
   for filename in resultfiles:
-    print filename
-    outcome = ReadAndPossiblyRewriteEncodingResult(filename)
+    outcome = ReadAndMaybeRewriteResult(filename)
     counter[outcome] += 1
     overall_counter += 1
   print counter
+  print 'Total: ', overall_counter
   return 0
 
 

--- a/lib/vp9.py
+++ b/lib/vp9.py
@@ -30,6 +30,7 @@ class Vp9Codec(file_codec.FileCodec):
       encoder.IntegerOption('cpu-used', 0, 16),
       # The "best" option gives encodes that are too slow to be useful.
       encoder.ChoiceOption(['good', 'rt']).Mandatory(),
+      encoder.IntegerOption('passes', 1, 2),
     )
 
   def StartEncoder(self, context):

--- a/lib/vp9_unittest.py
+++ b/lib/vp9_unittest.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Unit tests for encoder module."""
 
+import encoder
 import optimizer
 import unittest
 import test_tools
@@ -46,7 +47,24 @@ class TestVp9(test_tools.FileUsingCodecTest):
     codec = vp9.Vp9Codec()
     self.assertEqual('5000', codec.SpeedGroup(5000))
 
+  def test_Passes(self):
+    """This test checks that both 1-pass and 2-pass encoding works."""
+    codec = vp9.Vp9Codec()
+    my_optimizer = optimizer.Optimizer(codec)
+    videofile = test_tools.MakeYuvFileWithOneBlankFrame(
+      'one_black_frame_1024_768_30.yuv')
+    start_encoder = codec.StartEncoder(my_optimizer.context)
+    encoder1 = encoder.Encoder(my_optimizer.context,
+        start_encoder.parameters.ChangeValue('passes', 1))
+    encoding1 = encoder1.Encoding(1000, videofile)
+    encoder2 = encoder.Encoder(my_optimizer.context,
+        start_encoder.parameters.ChangeValue('passes', 2))
+    encoding2 = encoder2.Encoding(1000, videofile)
+    encoding1.Execute()
+    encoding2.Execute()
+    self.assertTrue(encoding1.result)
+    self.assertTrue(encoding2.result)
+
+
 if __name__ == '__main__':
   unittest.main()
-
-


### PR DESCRIPTION
This allows 1-pass and 2-pass to be exercised explicitly.
Also fix some pylint errors in a hack script submitted earlier.