### PR TITLE
Fixes qmin / qmax relationship on the mjpeg codec.

### DIFF
--- a/bin/randomly_improve_encoding
+++ b/bin/randomly_improve_encoding
@@ -28,7 +28,7 @@ import optimizer
 import score_tools
 import sys
 
-def TryToImprove(my_optimizer, filename, bitrate):
+def TryToImprove(my_optimizer, filename, bitrate, dry_run):
   """Try to improve an encoding. Return true if improved."""
   videofile = encoder.Videofile(filename)
   bestsofar = my_optimizer.BestEncoding(bitrate, videofile)
@@ -38,6 +38,9 @@ def TryToImprove(my_optimizer, filename, bitrate):
     previous_score = -10000
   next_encoding = my_optimizer.BestUntriedEncoding(bitrate, videofile)
   if next_encoding:
+    if dry_run:
+      print next_encoding.EncodeCommandLine()
+      return 'Dry run'
     print "Trying encoder", next_encoding.encoder.Hashname()
     next_encoding.Execute()
     print "Score is", my_optimizer.Score(next_encoding), ' from', previous_score
@@ -52,12 +55,15 @@ def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('--iterations', type=int, default=sys.maxint)
   parser.add_argument('--criterion', default='psnr')
+  parser.add_argument('--codecs', nargs='*', default=pick_codec.AllCodecNames())
+  parser.add_argument('--dry-run', action='store_true', default=False)
   args = parser.parse_args()
+  print 'Codecs are ', args.codecs
   tries = 0
   results = collections.Counter()
   while tries < args.iterations:
     tries += 1
-    codec = pick_codec.PickCodec(random.choice(pick_codec.AllCodecNames()))
+    codec = pick_codec.PickCodec(random.choice(args.codecs))
     my_optimizer = optimizer.Optimizer(codec,
         score_function=score_tools.PickScorer(args.criterion),
         file_set=mpeg_settings.MpegFiles())
@@ -66,7 +72,7 @@ def main():
 
     print "Trying codec %s on file %s rate %s" % (codec.name, filename,
                                                   bitrate)
-    result = TryToImprove(my_optimizer, filename, bitrate)
+    result = TryToImprove(my_optimizer, filename, bitrate, dry_run=args.dry_run)
     results[result] += 1
     print 'So far:', dict(results)
 

--- a/lib/mjpeg.py
+++ b/lib/mjpeg.py
@@ -32,3 +32,22 @@ class MotionJpegCodec(ffmpeg.FfmpegCodec):
     return encoder.Encoder(
       context, encoder.OptionValueSet(self.option_set, '',
                                       formatter=self.option_formatter))
+
+  def ConfigurationFixups(self, config):
+    """Ensure that qmin is less than qmax."""
+    if config.HasValue('qmin'):
+      qmin = int(config.GetValue('qmin'))
+    else:
+      qmin = self.option_set.Option('qmin').min
+
+    if config.HasValue('qmax'):
+      qmax = int(config.GetValue('qmax'))
+    else:
+      # It seems that the default for qmax is rather low - at least, there's
+      # an error saying "qmax is too low" when only -qmin 39 is given.
+      # From manual probing: qmin 31 succeeds, qmin 32 fails.
+      qmax = 31
+
+    if qmax < qmin:
+      return config.ChangeValue('qmax', str(qmin))
+    return config

--- a/lib/mjpeg_unittest.py
+++ b/lib/mjpeg_unittest.py
@@ -39,11 +39,32 @@ class TestMotionJpegCodec(test_tools.FileUsingCodecTest):
     videofile = test_tools.MakeYuvFileWithOneBlankFrame(
         'one_black_frame_1024_768_30.yuv')
     my_encoder = encoder.Encoder(my_optimizer.context,
-        encoder.OptionValueSet(codec.option_set, '-qmin 1 -qmax 1',
+        encoder.OptionValueSet(codec.option_set, '-qmin 1 -qmax 2',
                                formatter=codec.option_formatter))
     encoding = my_encoder.Encoding(5000, videofile)
     encoding.Execute()
     self.assertLess(50.0, my_optimizer.Score(encoding))
+
+  def test_ParametersAdjusted(self):
+    codec = mjpeg.MotionJpegCodec()
+    my_optimizer = optimizer.Optimizer(codec)
+    my_encoder = encoder.Encoder(my_optimizer.context,
+        encoder.OptionValueSet(codec.option_set, '-qmin 1 -qmax 1',
+                               formatter=codec.option_formatter))
+    self.assertEquals('1', my_encoder.parameters.GetValue('qmin'))
+    self.assertEquals('1', my_encoder.parameters.GetValue('qmax'))
+    # qmax is less than qmin. Should be adjusted to be above.
+    my_encoder = encoder.Encoder(my_optimizer.context,
+        encoder.OptionValueSet(codec.option_set, '-qmin 2 -qmax 1',
+                               formatter=codec.option_formatter))
+    self.assertEquals('2', my_encoder.parameters.GetValue('qmin'))
+    self.assertEquals('2', my_encoder.parameters.GetValue('qmax'))
+    # qmin is not given, qmax set below default for qmin.
+    my_encoder = encoder.Encoder(my_optimizer.context,
+        encoder.OptionValueSet(codec.option_set, '-qmax 0',
+                               formatter=codec.option_formatter))
+    self.assertEquals('1', my_encoder.parameters.GetValue('qmax'))
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This change ensures that qmax is always >= qmin when both are
specified for the mjpeg codec. It also ensures that qmax is given
if qmin > 31 (seems to be the hidden default for qmax).

It also adds a --dry-run flag to the randomly_improve_encoding script,
and the ability to randomly improve only for a single codec.