### PR TITLE
use the recommended command options for openh264

### DIFF
--- a/lib/openh264.py
+++ b/lib/openh264.py
@@ -41,9 +41,10 @@ class OpenH264Codec(file_codec.FileCodec):
         '-bf %s '
         '-sw %d -sh %d '
         '-dw 0 %d -dh 0 %d '
-        '-rc 0 -maxbrTotal %d -tarb %d '
+        '-rc 0 -maxbrTotal 0 -tarb %d '
         '-ltarb 0 %d '
-        '-lmaxb 0 %d '
+        '-lmaxb 0 0 '
+        '-fs 0' #disable FrameSkip with this option
         '%s ' % (
             encoder.Tool('.'),
             encoder.Tool('h264enc'),
@@ -52,8 +53,6 @@ class OpenH264Codec(file_codec.FileCodec):
             encodedfile,
             videofile.width, videofile.height,
             videofile.width, videofile.height,
-            bitrate,
-            bitrate,
             bitrate,
             bitrate,
             parameters.ToString()))

--- a/lib/openh264.py
+++ b/lib/openh264.py
@@ -44,7 +44,9 @@ class OpenH264Codec(file_codec.FileCodec):
         '-rc 0 -maxbrTotal 0 -tarb %d '
         '-ltarb 0 %d '
         '-lmaxb 0 0 '
-        '-fs 0' #disable FrameSkip with this option
+        '-frout 0 %d ' #this is to set the output frame rate, TODO: add option of input frame rate after the codec supports it
+        '-fs 0 ' #disable FrameSkip with this option
+        '-aq 0 ' #disable AdaptiveQuantizaion with this option
         '%s ' % (
             encoder.Tool('.'),
             encoder.Tool('h264enc'),
@@ -55,6 +57,7 @@ class OpenH264Codec(file_codec.FileCodec):
             videofile.width, videofile.height,
             bitrate,
             bitrate,
+            videofile.framerate,
             parameters.ToString()))
     return commandline
 


### PR DESCRIPTION
1, Suggest not to use the options -maxbrTotal and -lmaxb in performance tests like this, since these two will put stricter control on bit rate. Given the focus of openh264 is more on paced vbr, suggest not to use these constrictions in performance testing. Setting them to 0 which mean unspecified if there is no need to set them.
2, '-fs 0' can be used to disable EnableFrameSkip, regarding that this is PSNR test I use a constant here.  Seems there is no such variable in 'parameters'? Pls let me know if I should use a variable for this rather than a constant. Thx.
