### PR TITLE
Adding "rc" as a parameter to openh264

### DIFF
--- a/lib/openh264.py
+++ b/lib/openh264.py
@@ -28,6 +28,11 @@ class OpenH264Codec(file_codec.FileCodec):
       name,
       formatter=formatter or encoder.OptionFormatter(prefix='-', infix=' '))
     self.extension = '264'
+    self.option_set = encoder.OptionSet(
+      # Rate control. -1 = off, 0 = quality, 1 = bitrate, 2 = buffer based
+      # Default is set in config file by RCMode parameter to 0.
+      encoder.Option('rc', ['-1', '0', '1', '2'])
+    )
 
   def StartEncoder(self, context):
     return encoder.Encoder(context, encoder.OptionValueSet(self.option_set, ''))
@@ -41,7 +46,7 @@ class OpenH264Codec(file_codec.FileCodec):
         '-bf %s '
         '-sw %d -sh %d '
         '-dw 0 %d -dh 0 %d '
-        '-rc 0 -maxbrTotal 0 -tarb %d '
+        '-maxbrTotal 0 -tarb %d '
         '-ltarb 0 %d '
         '-lmaxb 0 0 '
         '-numtl 1 '

--- a/lib/openh264.py
+++ b/lib/openh264.py
@@ -31,7 +31,9 @@ class OpenH264Codec(file_codec.FileCodec):
     self.option_set = encoder.OptionSet(
       # Rate control. -1 = off, 0 = quality, 1 = bitrate, 2 = buffer based
       # Default is set in config file by RCMode parameter to 0.
-      encoder.Option('rc', ['-1', '0', '1', '2'])
+      # Only 0 and 1 really make sense when rate control is used to select
+      # the bitrate target.
+      encoder.Option('rc', ['0', '1'])
     )
 
   def StartEncoder(self, context):


### PR DESCRIPTION
This allows the "rc" parameter to be varied in order to try different
styles of rate control.
Best results are achieved with -rc 2, which has no rate control, but
better compression.