### PR TITLE
Update docs needed and suggest new options on frame rate and other setting of OpenH264

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@
 # The email address is not required for organizations.
 
 Google Inc.
+Cisco Systems Inc.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@
 #
 Harald Alvestrand <hta@chromium.org>
 Lou Quillio <louquillio@google.com>
+Sijia Chen <sijchen@cisco.com>

--- a/compile_tools.sh
+++ b/compile_tools.sh
@@ -146,14 +146,12 @@ build_openh264() {
     git clone git@github.com:cisco/openh264.git
   fi
   cd openh264
-  git checkout v1.4.0
+  # 7e3c064 is the version that enables the -frin option which will be used in scripts
+  git checkout 7e3c064
   make
   cp h264enc $TOOLDIR
   cp h264dec $TOOLDIR
-  # We have to modify a variable in the config, so can't do this.
-  # cp testbin/welsenc.cfg $TOOLDIR/openh264.cfg
-  sed -e 's/EnableFrameSkip[[:space:]]*1/EnableFrameSkip 0/' \
-      < testbin/welsenc.cfg > $TOOLDIR/openh264.cfg
+  cp testbin/welsenc.cfg $TOOLDIR/openh264.cfg
   cp testbin/layer2.cfg $TOOLDIR/layer2.cfg
 }
 

--- a/lib/openh264.py
+++ b/lib/openh264.py
@@ -44,7 +44,8 @@ class OpenH264Codec(file_codec.FileCodec):
         '-rc 0 -maxbrTotal 0 -tarb %d '
         '-ltarb 0 %d '
         '-lmaxb 0 0 '
-        '-frout 0 %d ' #this is to set the output frame rate, TODO: add option of input frame rate after the codec supports it
+        '-numtl 1 '
+        '-frin %d -frout 0 %d ' #this is to set the frame rate
         '-fs 0 ' #disable FrameSkip with this option
         '-aq 0 ' #disable AdaptiveQuantizaion with this option
         '%s ' % (
@@ -57,7 +58,7 @@ class OpenH264Codec(file_codec.FileCodec):
             videofile.width, videofile.height,
             bitrate,
             bitrate,
-            videofile.framerate,
+            videofile.framerate, videofile.framerate,
             parameters.ToString()))
     return commandline
 


### PR DESCRIPTION
about the new options: 
disabling temporal layer settings which is mainly for error robustness; tested with some sequences in webm fileset and the score seemed increased.