### PR TITLE
Add "--threads" parameter to x264 codec.

### DIFF
--- a/bin/vary_parameter
+++ b/bin/vary_parameter
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+# Copyright 2014 Google.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tweaker for the VP8 codec.
+
+Usage: vp8tweaker [--loop] <rate> <videofile>
+
+This script consults the run database for the VP8 codec,
+picks the best encoding so far, generates the tweak set for it,
+finds the encoding with the highest likely score that hasn't been
+encoded, executes the encoding, and reports whether or not there
+was improvement.
+"""
+
+import argparse
+import sys
+
+import encoder
+import optimizer
+import pick_codec
+import score_tools
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('rate')
+  parser.add_argument('videofile')
+  parser.add_argument("--codec")
+  parser.add_argument("--parameter")
+  parser.add_argument('--criterion', default='psnr')
+  args = parser.parse_args()
+
+  videofile = encoder.Videofile(args.videofile)
+
+  bitrate = int(args.rate)
+  args = parser.parse_args()
+
+  videofile = encoder.Videofile(args.videofile)
+
+  codec = pick_codec.PickCodec(args.codec)
+  my_optimizer = optimizer.Optimizer(codec,
+      score_function=score_tools.PickScorer(args.criterion))
+
+  bestsofar = my_optimizer.BestEncoding(bitrate, videofile)
+  for value in codec.Option(args.parameter).values:
+    this_encoding = bestsofar.ChangeValue(args.parameter, value)
+    this_encoding.Recover()
+    if not this_encoding.Result():
+      this_encoding.Execute()
+      this_encoding.Store()
+    print 'Score for value', value, 'is', my_optimizer.Score(this_encoding)
+
+if __name__ == '__main__':
+  sys.exit(main())
+

--- a/bin/vary_parameter
+++ b/bin/vary_parameter
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2014 Google.
+# Copyright 2015 Google.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tweaker for the VP8 codec.
+"""Parameter variation probing tool.
 
-Usage: vp8tweaker [--loop] <rate> <videofile>
+Usage: vary_parameter [--codec codec] [--criterion criterion]
+       --parameter name rate videofile
 
-This script consults the run database for the VP8 codec,
-picks the best encoding so far, generates the tweak set for it,
-finds the encoding with the highest likely score that hasn't been
-encoded, executes the encoding, and reports whether or not there
-was improvement.
+This script consults the run database for the codec,
+picks the best encoding so far, and runs the encodings for all the
+possible values of the parameter.
 """
 
 import argparse

--- a/lib/encoder.py
+++ b/lib/encoder.py
@@ -549,6 +549,10 @@ class Encoder(object):
                                                          videofile).encodings)
     return encodings
 
+  def ChangeValue(self, name, new_value):
+    """Return a new encoder with a changed value for this parameter."""
+    return Encoder(self.context, self.parameters.ChangeValue(name, new_value))
+
   def RandomlyRemoveParameter(self):
     parameters = self.parameters.RandomlyRemoveParameter()
     if parameters:
@@ -663,6 +667,11 @@ class Encoding(object):
 
   def Recover(self):
     self.result = self.context.cache.ReadEncodingResult(self)
+
+  def ChangeValue(self, name, value):
+    new_encoder = self.encoder.ChangeValue(name, value)
+    new_encoding = new_encoder.Encoding(self.bitrate, self.videofile)
+    return new_encoding
 
 
 # Utility functions for EncodingDiskCache.

--- a/lib/encoder_unittest.py
+++ b/lib/encoder_unittest.py
@@ -322,6 +322,16 @@ class TestEncoder(unittest.TestCase):
       # pylint: disable=W0612
       new_encoder = encoder.Encoder(context, filename=old_filename)
 
+  def test_Changevalue(self):
+    config = encoder.OptionValueSet(
+        encoder.OptionSet(encoder.Option('foo', ['foo', 'bar'])),
+        '--foo=foo')
+    context = encoder.Context(DummyCodec())
+    my_encoder = encoder.Encoder(context, config)
+    next_encoder = my_encoder.ChangeValue('foo', 'bar')
+    self.assertEquals(next_encoder.parameters, '--foo=bar')
+
+
 class TestEncoding(unittest.TestCase):
 
   def testGenerateSomeUntriedVariants(self):

--- a/lib/file_codec.py
+++ b/lib/file_codec.py
@@ -38,21 +38,25 @@ class FileCodec(encoder.Codec):
 
     print commandline
     with open('/dev/null', 'r') as nullinput:
-      subprocess_cpu_start = os.times()[2]
+      times_start = os.times()
       returncode = subprocess.call(commandline, shell=True, stdin=nullinput)
-      subprocess_cpu = os.times()[2] - subprocess_cpu_start
-      print "Encode took %f seconds" % subprocess_cpu
+      times_end = os.times()
+      subprocess_cpu = times_end[2] - times_start[2]
+      elapsed_clock = times_end[4] - times_start[4]
+      print "Encode took %f CPU seconds %f clock seconds" % (
+          subprocess_cpu, elapsed_clock)
       if returncode:
         raise Exception("Encode failed with returncode %d" % returncode)
-      return subprocess_cpu
+      return (subprocess_cpu, elapsed_clock)
 
   def Execute(self, parameters, bitrate, videofile, workdir):
     encodedfile = '%s/%s.%s' % (workdir, videofile.basename, self.extension)
-    subprocess_cpu = self._EncodeFile(parameters, bitrate, videofile,
-                                      encodedfile)
+    (subprocess_cpu, elapsed_clock) = self._EncodeFile(parameters, bitrate,
+                                                       videofile, encodedfile)
     result = {}
 
     result['encode_cputime'] = subprocess_cpu
+    result['encode_clocktime'] = elapsed_clock
     bitrate = videofile.MeasuredBitrate(os.path.getsize(encodedfile))
 
     tempyuvfile = "%s/%stempyuvfile.yuv" % (workdir, videofile.basename)

--- a/lib/file_codec.py
+++ b/lib/file_codec.py
@@ -51,7 +51,7 @@ class FileCodec(encoder.Codec):
 
   def Execute(self, parameters, bitrate, videofile, workdir):
     encodedfile = '%s/%s.%s' % (workdir, videofile.basename, self.extension)
-    (subprocess_cpu, elapsed_clock) = self._EncodeFile(parameters, bitrate,
+    subprocess_cpu, elapsed_clock = self._EncodeFile(parameters, bitrate,
                                                        videofile, encodedfile)
     result = {}
 

--- a/lib/file_codec_unittest.py
+++ b/lib/file_codec_unittest.py
@@ -69,6 +69,8 @@ class TestFileCodec(test_tools.FileUsingCodecTest):
     encoding = my_optimizer.BestEncoding(1000, videofile)
     encoding.Execute()
     self.assertTrue(encoding.Result())
+    self.assertIn('encode_cputime', encoding.Result())
+    self.assertIn('encode_clocktime', encoding.Result())
 
   def test_VerifyOneBlackFrame(self):
     codec = CopyingCodec()

--- a/lib/x264.py
+++ b/lib/x264.py
@@ -35,6 +35,7 @@ class X264Codec(file_codec.FileCodec):
       encoder.ChoiceOption(['use-vbv-maxrate']),
       encoder.Option('profile', ['baseline', 'main', 'high']),
       encoder.Option('tune', ['psnr', 'ssim']),
+      encoder.IntegerOption('threads', 1, 64).Mandatory(),
       encoder.DummyOption('vbv-maxrate'),
       encoder.DummyOption('vbv-bufsize'),
     )
@@ -56,7 +57,6 @@ class X264Codec(file_codec.FileCodec):
       parameters = parameters.ChangeValue('vbv-bufsize', str(bitrate))
     commandline = ('%(x264)s '
       '--bitrate %(bitrate)d --fps %(framerate)d '
-      '--threads 1 '
       '--input-res %(width)dx%(height)d '
       '--quiet '
       '%(parameters)s '

--- a/lib/x264.py
+++ b/lib/x264.py
@@ -35,7 +35,11 @@ class X264Codec(file_codec.FileCodec):
       encoder.ChoiceOption(['use-vbv-maxrate']),
       encoder.Option('profile', ['baseline', 'main', 'high']),
       encoder.Option('tune', ['psnr', 'ssim']),
-      encoder.IntegerOption('threads', 1, 64).Mandatory(),
+      # Experimentation on a 6-core, 12-thread system shows some gains on
+      # large videos for thread values up to the thread count, and up to the
+      # core count on smaller videos.
+      # There is some damage to PSNR with more threads.
+      encoder.IntegerOption('threads', 1, 6).Mandatory(),
       encoder.DummyOption('vbv-maxrate'),
       encoder.DummyOption('vbv-bufsize'),
     )

--- a/lib/x264_unittest.py
+++ b/lib/x264_unittest.py
@@ -64,6 +64,20 @@ class TestX264(test_tools.FileUsingCodecTest):
     self.assertRegexpMatches(commandline, '--vbv-maxrate 1000 ')
     self.assertNotRegexpMatches(commandline, 'use-vbv-maxrate')
 
+  def test_Threading(self):
+    codec = x264.X264Codec()
+    context = encoder.Context(codec, encoder.EncodingDiskCache)
+    one_thread_encoder = codec.StartEncoder(context).ChangeValue('threads', 1)
+    two_thread_encoder = codec.StartEncoder(context).ChangeValue('threads', 2)
+    videofile = test_tools.MakeYuvFileWithOneBlankFrame(
+        'one_black_frame_1024_768_30.yuv')
+    one_encoding = one_thread_encoder.Encoding(1000, videofile)
+    one_encoding.Execute()
+    two_encoding = two_thread_encoder.Encoding(1000, videofile)
+    two_encoding.Execute()
+    self.assertAlmostEquals(float(one_encoding.Result()['psnr']),
+                            float(two_encoding.Result()['psnr']))
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This adds a parameter for controlling the number of threads to
the x264 codec, removing the previously hardcoded default.
NOTE: WILL INVALIDATE STORED ENCODES.

It also adds a new tool "vary_parameter" that lets one run encodes
for all possible values of a parameter, so that response curves
can be seen.

It also fixes a minor Lint error in openh264.py.