### PR TITLE
Make bad configurations cause errors.

### DIFF
--- a/bin/run_all_tests
+++ b/bin/run_all_tests
@@ -52,6 +52,6 @@ echo "Checking license statements"
 grep -L 'Licensed under the Apache' lib/*.py
 # Because the second grep returns 1 when there are no files found, we must
 # invert the exit status.
-! grep -L 'Licensed under the Apache' bin/*[a-z] | grep -v '\.pyc$'
+grep -L 'Licensed under the Apache' bin/*[a-z] | grep -v '\.pyc$' && exit 1
 
 echo "All good"

--- a/bin/run_all_tools
+++ b/bin/run_all_tools
@@ -16,8 +16,8 @@
 # Test tool for tools.
 #
 # This script will run all the tools except those commented out because they
-# have too interesting side effects.
-# This is not a test suite, just a sanity check.
+# have too interesting side effects or take too much time.
+# This is not a comprehensive test suite, just a sanity check.
 #
 set -e
 # Show commands as they are executed
@@ -34,6 +34,13 @@ else
   parameter_tweaker $RATE $VIDEOFILE
 fi
 
+# Note: verify_stored_parameters actually verifies the result storage,
+# which is important to do before checking in new code.
+# Run verify_stored_parameters --remove to get rid of bad configurations.
+verify_stored_parameters
+
+# Other tools are just run to verify that they can be started.
+# Tools that take too long are skipped.
 compare_codecs vp8 vp9 > /dev/null
 compare_json vp8 vp9 > /dev/null
 force_run_config --codec h261 -- ''
@@ -43,6 +50,5 @@ randomly_improve_encoding --iterations 1
 sensitivity_analysis > /dev/null
 # take_snapshot
 verify_encodings h261
-verify_hashnames h261
 verify_scores h261
 write_cross_performance_tables h261 vp8 > /dev/null

--- a/bin/sensitivity_analysis
+++ b/bin/sensitivity_analysis
@@ -36,8 +36,12 @@ def AnalyzeVariants(encoding, score=False):
       _ = option.max
       value = int(encoding.encoder.parameters.GetValue(option.name))
     except ValueError:
+      # This will happen if the value can't be parsed as an int.
       continue
     except AttributeError:
+      continue
+    except encoder.Error:
+      # This will happen for "no value for this option".
       continue
     # Hackish!
     if value > option.min:

--- a/bin/vary_parameter
+++ b/bin/vary_parameter
@@ -30,6 +30,7 @@ import optimizer
 import pick_codec
 import score_tools
 
+
 def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('rate')

--- a/bin/verify_stored_parameters
+++ b/bin/verify_stored_parameters
@@ -30,6 +30,31 @@ import sys
 import encoder
 import pick_codec
 
+def IssuesOnOneParameterSet(context, filename):
+  something_changed = False
+  try:
+    my_encoder = encoder.Encoder(context, filename=filename)
+    new_parameters = context.codec.ConfigurationFixups(my_encoder.parameters)
+    if new_parameters != my_encoder.parameters:
+      print 'Error: Parameters change at fixup for codec %s encoder %s' % (
+          codec.name, filename)
+      print 'Old:', my_encoder.parameters.ToString()
+      print ('New: %s'
+             % new_parameters.ToString())
+      something_changed = True
+  except (encoder.ParseError) as error:
+    print 'Parse error in codec %s encoder %s: %s' % (
+        context.codec.name, filename, error)
+    something_changed = True
+  except (encoder.Error, IOError) as error:
+    # encoder.Error is raised if there's a checksum change.
+    # IOError is raised if the encoder directory is corrupted,
+    # for instance if the parameter file is missing.
+    print 'Error in codec %s encoder %s: %s' % (
+        context.codec.name, filename, error)
+    something_changed = True
+  return something_changed
+
 def VerifyHashnames(codecs, remove_offending_encoders):
   change_count = 0
   for codec_name in codecs:
@@ -40,29 +65,7 @@ def VerifyHashnames(codecs, remove_offending_encoders):
     context = encoder.Context(codec, cache_class=encoder.EncodingDiskCache)
     filenames = context.cache.AllEncoderFilenames()
     for filename in filenames:
-      something_changed = False
-      try:
-        my_encoder = encoder.Encoder(context, filename=filename)
-        new_parameters = codec.ConfigurationFixups(my_encoder.parameters)
-        if new_parameters != my_encoder.parameters:
-          print 'Error: Parameters change at fixup for codec %s encoder %s' % (
-              codec.name, filename)
-          print 'Old:', my_encoder.parameters.ToString()
-          print ('New: %s'
-                 % new_parameters.ToString())
-          something_changed = True
-      except (encoder.ParseError) as error:
-        print 'Parse error in codec %s encoder %s: %s' % (
-            codec.name, filename, error)
-        something_changed = True
-      except (encoder.Error, IOError) as error:
-        # encoder.Error is raised if there's a checksum change.
-        # IOError is raised if the encoder directory is corrupted,
-        # for instance if the parameter file is missing.
-        print 'Error in codec %s encoder %s: %s' % (
-            codec.name, filename, error)
-        something_changed = True
-      if something_changed:
+      if IssuesOnOneParameterSet(context, filename):
         if remove_offending_encoders:
           print 'Deleting encoder %s' % filename
           context.cache.RemoveEncoder(filename)
@@ -76,7 +79,7 @@ def main():
                       default=pick_codec.AllCodecNames())
   args = parser.parse_args()
   change_count = VerifyHashnames(args.codecs, args.remove)
-  print 'Number of changes: %d' % change_count
+  print 'Number of issues: %d' % change_count
   if change_count > 0 and not args.remove:
     return 1
   return 0

--- a/bin/verify_stored_parameters
+++ b/bin/verify_stored_parameters
@@ -13,11 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This script verifies that hashes for all encoders are correct.
+# This script verifies that stored parameters for all encoders are correct.
 #
 # The encoder is stored in a directory that is named by a hash over
 # its string representation. If the string representation changes,
 # the hash will change, and therefore the old directory becomes invalid.
+#
+# Also, the legal parameters for a codec may change. This will result in
+# an error when trying to retrieve the parameter set.
+#
+# The script has an option to delete offending encoders.
 #
 import argparse
 import sys
@@ -35,25 +40,29 @@ def VerifyHashnames(codecs, remove_offending_encoders):
     context = encoder.Context(codec, cache_class=encoder.EncodingDiskCache)
     filenames = context.cache.AllEncoderFilenames()
     for filename in filenames:
+      something_changed = False
       try:
         my_encoder = encoder.Encoder(context, filename=filename)
-        if (codec.ConfigurationFixups(my_encoder.parameters)
-            != my_encoder.parameters):
-          print 'Error: Parameter change for codec %s encoder %s' % (
+        new_parameters = codec.ConfigurationFixups(my_encoder.parameters)
+        if (new_parameters != my_encoder.parameters):
+          print 'Error: Parameters change at fixup for codec %s encoder %s' % (
               codec.name, filename)
           print 'Old:', my_encoder.parameters.ToString()
           print ('New: %s'
-                 % codec.ConfigurationFixups(my_encoder.parameters).ToString())
-          if remove_offending_encoders:
-            print 'Deleting encoder %s' % filename
-            context.cache.RemoveEncoder(filename)
-          change_count += 1
+                 % new_parameters.ToString())
+          something_changed = True
+      except (encoder.ParseError) as error:
+        print 'Parse error in codec %s encoder %s: %s' % (
+            codec.name, filename, error)
+        something_changed = True
       except (encoder.Error, IOError) as error:
         # encoder.Error is raised if there's a checksum change.
         # IOError is raised if the encoder directory is corrupted,
         # for instance if the parameter file is missing.
         print 'Error in codec %s encoder %s: %s' % (
             codec.name, filename, error)
+        something_changed = True
+      if something_changed:
         if remove_offending_encoders:
           print 'Deleting encoder %s' % filename
           context.cache.RemoveEncoder(filename)
@@ -68,7 +77,7 @@ def main():
   args = parser.parse_args()
   change_count = VerifyHashnames(args.codecs, args.remove)
   print 'Number of changes: %d' % change_count
-  if change_count > 0:
+  if change_count > 0 and not args.remove:
     return 1
   return 0
 

--- a/bin/verify_stored_parameters
+++ b/bin/verify_stored_parameters
@@ -37,7 +37,7 @@ def IssuesOnOneParameterSet(context, filename):
     new_parameters = context.codec.ConfigurationFixups(my_encoder.parameters)
     if new_parameters != my_encoder.parameters:
       print 'Error: Parameters change at fixup for codec %s encoder %s' % (
-          codec.name, filename)
+          context.codec.name, filename)
       print 'Old:', my_encoder.parameters.ToString()
       print ('New: %s'
              % new_parameters.ToString())

--- a/bin/verify_stored_parameters
+++ b/bin/verify_stored_parameters
@@ -44,7 +44,7 @@ def VerifyHashnames(codecs, remove_offending_encoders):
       try:
         my_encoder = encoder.Encoder(context, filename=filename)
         new_parameters = codec.ConfigurationFixups(my_encoder.parameters)
-        if (new_parameters != my_encoder.parameters):
+        if new_parameters != my_encoder.parameters:
           print 'Error: Parameters change at fixup for codec %s encoder %s' % (
               codec.name, filename)
           print 'Old:', my_encoder.parameters.ToString()

--- a/lib/encoder_unittest.py
+++ b/lib/encoder_unittest.py
@@ -244,6 +244,18 @@ class TestOptionValueSet(unittest.TestCase):
     newconfig = config.RandomlyRemoveParameter()
     self.assertFalse(newconfig)
 
+  def test_MissingMandatoryFailsToParse(self):
+    options = encoder.OptionSet(
+        encoder.Option('foo', ['foo', 'bar']).Mandatory())
+    with self.assertRaises(encoder.ParseError):
+      encoder.OptionValueSet(options, '')
+
+  def test_UnlistedValueFailsToParse(self):
+    options = encoder.OptionSet(
+        encoder.Option('foo', ['foo', 'bar']).Mandatory())
+    with self.assertRaises(encoder.ParseError):
+      encoder.OptionValueSet(options, '--foo=nonsense')
+
 
 class TestCodec(unittest.TestCase):
   def setUp(self):

--- a/lib/file_codec.py
+++ b/lib/file_codec.py
@@ -111,6 +111,8 @@ class FileCodec(encoder.Codec):
     """Returns true if a new encode of the file gives exactly the same file."""
     old_encoded_file = '%s/%s.%s' % (workdir, videofile.basename,
                                      self.extension)
+    if not os.path.isfile(old_encoded_file):
+      raise encoder.Error('Old encoded file missing: %s' % old_encoded_file)
     new_encoded_file = '%s/%s_verify.%s' % (workdir, videofile.basename,
                                             self.extension)
     self._EncodeFile(parameters, bitrate, videofile,

--- a/lib/mjpeg_unittest.py
+++ b/lib/mjpeg_unittest.py
@@ -49,21 +49,16 @@ class TestMotionJpegCodec(test_tools.FileUsingCodecTest):
     codec = mjpeg.MotionJpegCodec()
     my_optimizer = optimizer.Optimizer(codec)
     my_encoder = encoder.Encoder(my_optimizer.context,
-        encoder.OptionValueSet(codec.option_set, '-qmin 1 -qmax 1',
-                               formatter=codec.option_formatter))
-    self.assertEquals('1', my_encoder.parameters.GetValue('qmin'))
-    self.assertEquals('1', my_encoder.parameters.GetValue('qmax'))
-    # qmax is less than qmin. Should be adjusted to be above.
-    my_encoder = encoder.Encoder(my_optimizer.context,
-        encoder.OptionValueSet(codec.option_set, '-qmin 2 -qmax 1',
+        encoder.OptionValueSet(codec.option_set, '-qmin 2 -qmax 2',
                                formatter=codec.option_formatter))
     self.assertEquals('2', my_encoder.parameters.GetValue('qmin'))
     self.assertEquals('2', my_encoder.parameters.GetValue('qmax'))
-    # qmin is not given, qmax set below default for qmin.
+    # qmax is less than qmin. Should be adjusted to be above.
     my_encoder = encoder.Encoder(my_optimizer.context,
-        encoder.OptionValueSet(codec.option_set, '-qmax 0',
+        encoder.OptionValueSet(codec.option_set, '-qmin 3 -qmax 2',
                                formatter=codec.option_formatter))
-    self.assertEquals('1', my_encoder.parameters.GetValue('qmax'))
+    self.assertEquals('3', my_encoder.parameters.GetValue('qmin'))
+    self.assertEquals('3', my_encoder.parameters.GetValue('qmax'))
 
 
 if __name__ == '__main__':

--- a/lib/optimizer_unittest.py
+++ b/lib/optimizer_unittest.py
@@ -27,7 +27,7 @@ class DummyCodec(encoder.Codec):
     super(DummyCodec, self).__init__('dummy')
     self.extension = 'fake'
     self.option_set = encoder.OptionSet(
-      encoder.Option('score', ['0', '5', '10']),
+      encoder.IntegerOption('score', 0, 10),
       encoder.Option('another_parameter', ['yes']),
     )
 

--- a/lib/x264.py
+++ b/lib/x264.py
@@ -47,7 +47,7 @@ class X264Codec(file_codec.FileCodec):
   def StartEncoder(self, context):
     return encoder.Encoder(context, encoder.OptionValueSet(
       self.option_set,
-      '--preset slow --tune psnr',
+      '--preset slow --tune psnr --threads 1',
       formatter=self.option_formatter))
 
 

--- a/lib/x264_baseline.py
+++ b/lib/x264_baseline.py
@@ -28,5 +28,5 @@ class X264BaselineCodec(x264.X264Codec):
   def StartEncoder(self, context):
     return encoder.Encoder(context, encoder.OptionValueSet(
       self.option_set,
-      '--profile baseline --preset slow --tune psnr',
+      '--profile baseline --preset slow --tune psnr --threads 1',
       formatter=self.option_formatter))

--- a/lib/x264_realtime.py
+++ b/lib/x264_realtime.py
@@ -28,5 +28,5 @@ class X264RealtimeCodec(x264.X264Codec):
   def StartEncoder(self, context):
     return encoder.Encoder(context, encoder.OptionValueSet(
       self.option_set,
-      '--rc-lookahead 0 --preset faster --tune psnr',
+      '--rc-lookahead 0 --preset faster --tune psnr --threads 4',
       formatter=self.option_formatter))


### PR DESCRIPTION
This makes configurations with:
- Missing mandatory options
- Options with undefined values
return error when one attempts to parse them.

Unrecognized parameters are still allowed.

The "verify_hashnames" script has been renamed to
"verify_stored_parameters" and changed a bit to reflect that it
also checks that parameters can be parsed.