### PR TITLE
Travis build activation: Travis file and test fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+# Copyright 2014 Google.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Travis configuration file.
+#
+# Note that install and test are customized for Travis - the total
+# compile cycle takes too many minutes, so we compile as little as possible.
+#
+language: python
+python: 2.7
+install:
+ - . init.sh
+ - ./install_software.sh travis
+script:
+ - . init.sh
+ - run_all_tests travis
+

--- a/bin/pylint
+++ b/bin/pylint
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Copyright 2014 Google.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Runs pylint out of third_party/depot_tools.
+#
+$WORKDIR/third_party/depot_tools/pylint $@

--- a/bin/run_all_tests
+++ b/bin/run_all_tests
@@ -17,28 +17,41 @@
 #
 set -e
 
+MODE=full
+if [ "$1" = "travis" ]; then
+  MODE=travis
+fi
+
 LIBDIR=$WORKDIR/lib
 
 $LIBDIR/encoder_unittest.py
 $LIBDIR/score_tools_unittest.py
 $LIBDIR/optimizer_unittest.py
 $LIBDIR/pick_codec_unittest.py
-$LIBDIR/file_codec_unittest.py
 $LIBDIR/visual_metrics_unittest.py
-$LIBDIR/vp8_unittest.py
-$LIBDIR/vp8_mpeg_unittest.py
-$LIBDIR/vp8_mpeg_1d_unittest.py
-$LIBDIR/x264_unittest.py
-$LIBDIR/h261_unittest.py
-$LIBDIR/mjpeg_unittest.py
-$LIBDIR/vp9_unittest.py
+if [ "$MODE" = "full" ]; then
+  $LIBDIR/file_codec_unittest.py
+  $LIBDIR/vp8_unittest.py
+  $LIBDIR/vp8_mpeg_unittest.py
+  $LIBDIR/vp8_mpeg_1d_unittest.py
+  $LIBDIR/x264_unittest.py
+  $LIBDIR/h261_unittest.py
+  $LIBDIR/mjpeg_unittest.py
+  $LIBDIR/vp9_unittest.py
+  # Large tests
+  $LIBDIR/optimizer_largetest.py
+else
+  echo "Skipping some tests in mode $MODE"
+fi
 
-# Large tests
-$LIBDIR/optimizer_largetest.py
 
 run_pylint
 
 echo "Checking license statements"
 # List files that do not have an Apache-license blurb in them.
 grep -L 'Licensed under the Apache' lib/*.py
-grep -L 'Licensed under the Apache' bin/*[a-z] | grep -v '\.pyc$'
+# Because the second grep returns 1 when there are no files found, we must
+# invert the exit status.
+! grep -L 'Licensed under the Apache' bin/*[a-z] | grep -v '\.pyc$'
+
+echo "All good"

--- a/install_software.sh
+++ b/install_software.sh
@@ -20,9 +20,14 @@
 #
 set -e
 
+MODE=full
+if [ "$1" = "travis" ]; then
+  MODE=nocompile
+fi
+
 # Requirements for compiling various packages and scripts.
 sudo apt-get install yasm mkvtoolnix mercurial cmake cmake-curses-gui \
-  build-essential yasm nasm
+  build-essential yasm nasm python-numpy
 
 # Install prerequisites for running Jekyll as a web server
 sudo apt-get install ruby1.9.1-dev nodejs
@@ -33,7 +38,16 @@ sudo apt-get install ruby1.9.1-dev nodejs
 # So we limit to a jekyll version that builds under 1.9.1.
 sudo gem install jekyll -v 1.5.1
 
+# Install travis linter
+sudo gem install travis-lint
+
+# Install depot_tools - we use the pylint from there
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git \
+   third_party/depot_tools
+
 # Compile from source everything that needs compiling.
-./compile_tools.sh
+if [ "$MODE" != "nocompile" ]; then
+  ./compile_tools.sh
+fi
 
 echo "All software installed"


### PR DESCRIPTION
This PR adds a Travis CI configuration, and modifies the
install_software and run_all_tests scripts in such a way that
the Travis CI tests can run without compiling binaries.

Compiling is possible under Travis, but it takes a long time;
tests should be fast.

Bugs were found and fixed.