### PR TITLE
Config path integration

### DIFF
--- a/bin/rewrite_ast_as_json
+++ b/bin/rewrite_ast_as_json
@@ -21,6 +21,7 @@ import json
 import glob
 import os
 import sys
+import encoder_configuration
 
 
 class Error(Exception):
@@ -59,7 +60,8 @@ def ReadAndMaybeRewriteResult(filename):
   return 'No file'
 
 def main():
-  resultfiles = glob.glob(os.environ['CODEC_WORKDIR'] + '/*/*/*/*.result')
+  resultfiles = glob.glob(encoder_configuration.conf.workdir()
+                          + '/*/*/*/*.result')
   print len(resultfiles), 'files found'
   counter = collections.Counter()
   overall_counter = 0

--- a/bin/verify_stored_parameters
+++ b/bin/verify_stored_parameters
@@ -63,7 +63,7 @@ def VerifyHashnames(codecs, remove_offending_encoders):
     # pylint: disable=maybe-no-member
     codec = pick_codec.PickCodec(codec_name)
     context = encoder.Context(codec, cache_class=encoder.EncodingDiskCache)
-    filenames = context.cache.AllEncoderFilenames()
+    filenames = context.cache.AllEncoderFilenames(only_workdir=True)
     for filename in filenames:
       if IssuesOnOneParameterSet(context, filename):
         if remove_offending_encoders:

--- a/init.sh
+++ b/init.sh
@@ -20,6 +20,11 @@ PATH=$(dedup "$PATH:$WORKDIR/bin")
 export PYTHONPATH=$(dedup "$PYTHONPATH:$WORKDIR/lib")
 export CODEC_WORKDIR=$WORKDIR/workdir
 export CODEC_TOOLPATH=$WORKDIR/tools
+if [ -d $WORKDIR/score_storage ]; then
+  export CODEC_SCOREPATH=$WORKDIR/score_storage
+else
+  export CODEC_SCOREPATH=''
+fi
 
 if [ ! -d $CODEC_WORKDIR ]; then
   mkdir $CODEC_WORKDIR

--- a/lib/encoder.py
+++ b/lib/encoder.py
@@ -26,13 +26,11 @@ An encoding is an encoder applied to a given filename and target bitrate.
 
 A variant is an encoder with at least one option changed.
 
-This module uses two external variables:
-
-os.getenv(CODEC_WORKDIR) gives the place where data is stored.
-os.getenv(CODEC_TOOLPATH) gives the directory of encoder/decoder tools.
+Configuration of the module is through the encoder_configuration module.
 """
 
 import ast
+import encoder_configuration
 import exceptions
 import glob
 import json
@@ -55,7 +53,7 @@ class ParseError(Error):
 
 
 def Tool(name):
-  return os.path.join(os.getenv('CODEC_TOOLPATH'), name)
+  return os.path.join(encoder_configuration.conf.tooldir(), name)
 
 
 class Option(object):
@@ -723,7 +721,7 @@ class EncodingDiskCache(object):
   def __init__(self, context):
     self.context = context
     # Default work directory is current directory.
-    self.workdir = '%s/%s' % (os.getenv('CODEC_WORKDIR'),
+    self.workdir = '%s/%s' % (encoder_configuration.conf.workdir(),
                               context.codec.name)
     if not os.path.isdir(self.workdir):
       os.mkdir(self.workdir)

--- a/lib/encoder_configuration.py
+++ b/lib/encoder_configuration.py
@@ -1,0 +1,45 @@
+# Copyright 2015 Google.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Configuration for the encoder and related functions.
+
+This module contains the code for reading the configuration from environment
+variables, and setters for overriding that configuration in tests.
+"""
+import os
+
+
+class Configuration(object):
+  def __init__(self):
+    self.work_directory = os.environ['CODEC_WORKDIR']
+    self.sys_directory = os.environ['WORKDIR']
+    self.tool_directory = os.environ['CODEC_TOOLPATH']
+
+  def workdir(self):
+    return self.work_directory
+
+  def sysdir(self):
+    return self.sys_directory
+
+  def tooldir(self):
+    return self.tool_directory
+
+  def override_workdir_for_test(self, test_workdir):
+    self.work_directory = test_workdir
+
+  def override_sysdir_for_test(self, test_sysdir):
+    self.sys_directory = test_sysdir
+
+# A static variable for holding the current configuration.
+# pylint: disable=invalid-name
+conf = Configuration()

--- a/lib/encoder_configuration.py
+++ b/lib/encoder_configuration.py
@@ -19,11 +19,19 @@ variables, and setters for overriding that configuration in tests.
 import os
 
 
+class Error(Exception):
+  pass
+
+
 class Configuration(object):
   def __init__(self):
     self.work_directory = os.environ['CODEC_WORKDIR']
     self.sys_directory = os.environ['WORKDIR']
     self.tool_directory = os.environ['CODEC_TOOLPATH']
+    self.score_path = os.getenv('CODEC_SCOREPATH', '').split(':')
+    # Splitting an empty string gives an 1-element result. Remove that.
+    if self.score_path == ['']:
+      self.score_path = []
 
   def workdir(self):
     return self.work_directory
@@ -34,11 +42,18 @@ class Configuration(object):
   def tooldir(self):
     return self.tool_directory
 
+  def scorepath(self):
+    """Additional directories to search for scores after workdir."""
+    return self.score_path
+
   def override_workdir_for_test(self, test_workdir):
     self.work_directory = test_workdir
 
   def override_sysdir_for_test(self, test_sysdir):
     self.sys_directory = test_sysdir
+
+  def override_scorepath_for_test(self, test_scorepath):
+    self.score_path = test_scorepath
 
 # A static variable for holding the current configuration.
 # pylint: disable=invalid-name

--- a/lib/encoder_configuration.py
+++ b/lib/encoder_configuration.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Configuration for the encoder and related functions.
 
 This module contains the code for reading the configuration from environment

--- a/lib/encoder_configuration_unittest.py
+++ b/lib/encoder_configuration_unittest.py
@@ -21,12 +21,30 @@ import encoder_configuration
 
 class TestConfiguration(unittest.TestCase):
   def test_defaults(self):
+    # These tests verify reading from the current environment.
+    # They should work no matter what the variables are set to,
+    # as long as required variables are set.
     self.assertEquals(os.environ['CODEC_WORKDIR'],
                       encoder_configuration.conf.workdir())
     self.assertEquals(os.environ['WORKDIR'],
                       encoder_configuration.conf.sysdir())
     self.assertEquals(os.environ['CODEC_TOOLPATH'],
                       encoder_configuration.conf.tooldir())
+    self.assertEquals(os.getenv('CODEC_SCOREPATH', ''),
+                      ':'.join(encoder_configuration.conf.scorepath()))
+
+  def test_scorepath_variants(self):
+    # This test works by modifying the environment and then creating
+    # a new configuration object. It does not use the global configuration
+    # object.
+    if 'CODEC_SCOREPATH' in os.environ:
+      del os.environ['CODEC_SCOREPATH']
+    os.environ['CODEC_WORKDIR'] = 'strange_string'
+    my_conf = encoder_configuration.Configuration()
+    self.assertEquals(0, len(my_conf.scorepath()))
+    os.environ['CODEC_SCOREPATH'] = 'a:b'
+    my_conf = encoder_configuration.Configuration()
+    self.assertEquals('a and b', ' and '.join(my_conf.scorepath()))
 
   def test_override(self):
     encoder_configuration.conf.override_workdir_for_test('new_value')

--- a/lib/encoder_configuration_unittest.py
+++ b/lib/encoder_configuration_unittest.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+# Copyright 2015 Google.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for encoder_configuration."""
+
+import os
+import unittest
+import encoder_configuration
+
+
+class TestConfiguration(unittest.TestCase):
+  def test_defaults(self):
+    self.assertEquals(os.environ['CODEC_WORKDIR'],
+                      encoder_configuration.conf.workdir())
+    self.assertEquals(os.environ['WORKDIR'],
+                      encoder_configuration.conf.sysdir())
+    self.assertEquals(os.environ['CODEC_TOOLPATH'],
+                      encoder_configuration.conf.tooldir())
+
+  def test_override(self):
+    encoder_configuration.conf.override_workdir_for_test('new_value')
+    self.assertEquals('new_value',
+                      encoder_configuration.conf.workdir())
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/lib/encoder_configuration_unittest.py
+++ b/lib/encoder_configuration_unittest.py
@@ -44,7 +44,7 @@ class TestConfiguration(unittest.TestCase):
     self.assertEquals(0, len(my_conf.scorepath()))
     os.environ['CODEC_SCOREPATH'] = 'a:b'
     my_conf = encoder_configuration.Configuration()
-    self.assertEquals('a and b', ' and '.join(my_conf.scorepath()))
+    self.assertEquals(['a', 'b'], my_conf.scorepath())
 
   def test_override(self):
     encoder_configuration.conf.override_workdir_for_test('new_value')

--- a/lib/encoder_unittest.py
+++ b/lib/encoder_unittest.py
@@ -413,6 +413,12 @@ class TestEncodingDiskCache(test_tools.FileUsingCodecTest):
     cache = encoder.EncodingDiskCache(StorageOnlyContext())
     self.assertTrue(cache)
 
+  def testSearchPath(self):
+    cache = encoder.EncodingDiskCache(StorageOnlyContext())
+    path = cache.SearchPath()
+    self.assertEquals(1 + len(encoder_configuration.conf.scorepath()),
+                      len(path))
+
   def testStoreFetchEncoder(self):
     context = StorageOnlyContext()
     cache = encoder.EncodingDiskCache(context)

--- a/lib/encoder_unittest.py
+++ b/lib/encoder_unittest.py
@@ -11,9 +11,10 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the License.te
 """Unit tests for encoder module."""
 
+import encoder_configuration
 import os
 import re
 import shutil
@@ -490,7 +491,7 @@ class TestEncodingDiskCache(test_tools.FileUsingCodecTest):
 
   def testReadResultFromAlternateDir(self):
     context = StorageOnlyContext()
-    otherdir = os.path.join(os.environ['CODEC_WORKDIR'], 'otherdir')
+    otherdir = os.path.join(encoder_configuration.conf.workdir(), 'otherdir')
     cache = encoder.EncodingDiskCache(context)
     my_encoder = encoder.Encoder(
         context,
@@ -505,7 +506,7 @@ class TestEncodingDiskCache(test_tools.FileUsingCodecTest):
     my_encoding.result = None
     result = cache.ReadEncodingResult(my_encoding, scoredir=otherdir)
     self.assertIsNone(result)
-    shutil.copytree(os.environ['CODEC_WORKDIR'], otherdir)
+    shutil.copytree(encoder_configuration.conf.workdir(), otherdir)
     result = cache.ReadEncodingResult(my_encoding, scoredir=otherdir)
     self.assertEquals(result, testresult)
 

--- a/lib/optimizer.py
+++ b/lib/optimizer.py
@@ -162,22 +162,24 @@ class Optimizer(object):
     all_scored_encodings = self.context.cache.AllScoredEncodings(
         files_and_rates[0][0],
         encoder.Videofile(files_and_rates[0][1]))
-    candidate_encoders = set([x.encoder.Hashname()
+    candidate_encoder_ids = set([x.encoder.Hashname()
+                                for x in all_scored_encodings])
+    candidate_encoders = dict([(x.encoder.Hashname(), x.encoder)
                               for x in all_scored_encodings])
     for rate, filename in files_and_rates[1:]:
       these_encoders = set([x.encoder.Hashname()
                             for x in self.context.cache.AllScoredEncodings(
                               rate, encoder.Videofile(filename))])
-      candidate_encoders.intersection_update(these_encoders)
-    if len(candidate_encoders) == 0:
+      candidate_encoder_ids.intersection_update(these_encoders)
+    if len(candidate_encoder_ids) == 0:
       return None
-    if len(candidate_encoders) == 1:
-      return encoder.Encoder(self.context, filename=candidate_encoders.pop())
+    if len(candidate_encoder_ids) == 1:
+      return candidate_encoders[candidate_encoder_ids.pop()]
     best_score = -10000
     best_encoder = None
-    for hashname in candidate_encoders:
+    for hashname in candidate_encoder_ids:
       this_total = 0
-      this_encoder = encoder.Encoder(self.context, filename=hashname)
+      this_encoder = candidate_encoders[hashname]
       for rate, filename in files_and_rates:
         this_encoding = this_encoder.Encoding(rate, encoder.Videofile(filename))
         this_encoding.Recover()

--- a/lib/optimizer_unittest.py
+++ b/lib/optimizer_unittest.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 """ Unit tests for the optimizer. """
-import os
 import re
 import unittest
 
 import encoder
+import encoder_configuration
 import optimizer
 import test_tools
 
@@ -276,7 +276,7 @@ class TestFileAndRateSetWithRealFiles(test_tools.FileUsingCodecTest):
     file_name = 'file_1024_768_30.yuv'
     test_tools.MakeYuvFileWithOneBlankFrame(file_name)
     the_set.AddFilesAndRates([file_name], [100],
-                             basedir=os.getenv('CODEC_WORKDIR'))
+                             basedir=encoder_configuration.conf.workdir())
     self.assertTrue(the_set.AllFilesAndRates())
     self.assertTrue(the_set.set_is_complete)
 

--- a/lib/optimizer_unittest.py
+++ b/lib/optimizer_unittest.py
@@ -227,6 +227,48 @@ class TestOptimizer(unittest.TestCase):
                       best_encoder.parameters.ToString())
 
 
+class TestOptimizerWithRealFiles(test_tools.FileUsingCodecTest):
+  def setUp(self):
+    self.codec = DummyCodec()
+    self.file_set = None
+    self.score_function = None
+    self.videofile = DummyVideofile('foofile_640_480_30.yuv', clip_time=1)
+    self.optimizer = None
+
+  def EncoderFromParameterString(self, parameter_string):
+    return encoder.Encoder(self.optimizer.context,
+        encoder.OptionValueSet(self.optimizer.context.codec.option_set,
+                               parameter_string))
+
+  def test_BestOverallConfigurationNotInWorkDirectory(self):
+    other_dir = encoder_configuration.conf.sysdir() + '/multirepo_test'
+    encoder_configuration.conf.override_scorepath_for_test([other_dir])
+
+    self.file_set = optimizer.FileAndRateSet(verify_files_present=False)
+    self.file_set.AddFilesAndRates([self.videofile.filename], [100, 200])
+    self.optimizer = optimizer.Optimizer(self.codec, self.file_set)
+    # When there is nothing in the database, None should be returned.
+    best_encoder = self.optimizer.BestOverallEncoder()
+    self.assertIsNone(best_encoder)
+    # Fill in the database with all the files and rates.
+    my_encoder = self.EncoderFromParameterString('--score=7')
+    my_encoder.context.cache.StoreEncoder(my_encoder, workdir=other_dir)
+    my_encoder.context.cache.StoreEncoder(my_encoder)
+    for rate, filename in self.file_set.AllFilesAndRates():
+      my_encoding = my_encoder.Encoding(rate, encoder.Videofile(filename))
+      my_encoding.Execute()
+      my_encoding.context.cache.StoreEncoding(my_encoding, workdir=other_dir)
+    # The best encoder should now be from the workdir, but the results are
+    # all fetched from the searchpath.
+    best_encoder = self.optimizer.BestOverallEncoder()
+    self.assertTrue(best_encoder)
+    self.assertEquals(my_encoder.parameters.ToString(),
+                      best_encoder.parameters.ToString())
+    one_encoding = best_encoder.Encoding(100, self.videofile)
+    one_encoding.Recover()
+    self.assertTrue(one_encoding.Result())
+
+
 class TestFileAndRateSet(unittest.TestCase):
 
   def test_OneFileAddedAndReturned(self):

--- a/lib/test_tools.py
+++ b/lib/test_tools.py
@@ -30,6 +30,7 @@ def InitWorkDir():
     os.mkdir(dirname)
   encoder_configuration.conf.override_workdir_for_test(dirname)
   encoder_configuration.conf.override_sysdir_for_test(dirname)
+  encoder_configuration.conf.override_scorepath_for_test([])
   return dirname
 
 def MakeYuvFileWithBlankFrames(name, count):

--- a/lib/test_tools.py
+++ b/lib/test_tools.py
@@ -21,21 +21,22 @@ import tempfile
 import unittest
 
 import encoder
+import encoder_configuration
 import optimizer
 
 def InitWorkDir():
   dirname = tempfile.mkdtemp(prefix='codec-unittest-workdir')
   if not os.path.isdir(dirname):
     os.mkdir(dirname)
-  os.environ['CODEC_WORKDIR'] = dirname
-  os.environ['WORKDIR'] = dirname
+  encoder_configuration.conf.override_workdir_for_test(dirname)
+  encoder_configuration.conf.override_sysdir_for_test(dirname)
   return dirname
 
 def MakeYuvFileWithBlankFrames(name, count):
   """Make an YUV file with one or more blank frames (all zeroes).
 
   The size of the frame is encoded in the filename."""
-  videofile = encoder.Videofile('%s/%s' % (os.getenv('CODEC_WORKDIR'),
+  videofile = encoder.Videofile('%s/%s' % (encoder_configuration.conf.workdir(),
                                            name))
   # Frame size in an YUV 4:2:0 file is 1.5 bytes per pixel.
   framesize = videofile.width * videofile.height * 3 / 2
@@ -45,7 +46,7 @@ def MakeYuvFileWithBlankFrames(name, count):
 
 def MakeYuvFileWithNoisyFrames(name, count):
   """Make an YUV file with one or more frames containing noise."""
-  videofile = encoder.Videofile('%s/%s' % (os.getenv('CODEC_WORKDIR'),
+  videofile = encoder.Videofile('%s/%s' % (encoder_configuration.conf.workdir(),
                                            name))
   # Frame size in an YUV 4:2:0 file is 1.5 bytes per pixel.
   framesize = videofile.width * videofile.height * 3 / 2
@@ -61,7 +62,7 @@ def MakeYuvFileWithOneBlankFrame(name):
 
 def FinishWorkDir(dirname):
   # Verification of validity
-  if os.environ['CODEC_WORKDIR'] != dirname:
+  if encoder_configuration.conf.workdir() != dirname:
     raise encoder.Error('Dirname was wrong in FinishWorkDir')
   shutil.rmtree(dirname)
 
@@ -73,7 +74,7 @@ def TestFileSet():
   the_set = optimizer.FileAndRateSet()
   filename = 'one_black_frame_1024_768_30.yuv'
   MakeYuvFileWithOneBlankFrame(filename)
-  my_directory = os.environ['CODEC_WORKDIR']
+  my_directory = encoder_configuration.conf.workdir()
   the_set.AddFilesAndRates([filename],
                            [300, 1000, 3000],
                            my_directory)

--- a/lib/test_tools.py
+++ b/lib/test_tools.py
@@ -28,9 +28,9 @@ def InitWorkDir():
   dirname = tempfile.mkdtemp(prefix='codec-unittest-workdir')
   if not os.path.isdir(dirname):
     os.mkdir(dirname)
-  os.mkdir(dirname + '/workdir')
-  encoder_configuration.conf.override_workdir_for_test(dirname +
-                                                       '/workdir')
+  os.mkdir(os.path.join(dirname, 'workdir'))
+  encoder_configuration.conf.override_workdir_for_test(
+      os.path.join(dirname, 'workdir'))
   encoder_configuration.conf.override_sysdir_for_test(dirname)
   encoder_configuration.conf.override_scorepath_for_test([])
   return dirname
@@ -65,7 +65,7 @@ def MakeYuvFileWithOneBlankFrame(name):
 
 def EmptyWorkDirectory():
   dirname = encoder_configuration.conf.workdir()
-  if dirname[0:4] != '/tmp':
+  if not dirname.startswith(tempfile.gettempdir()):
     raise encoder.Error('Workdir is %s, not a tempfile' % dirname)
   shutil.rmtree(dirname)
   os.mkdir(dirname)
@@ -73,7 +73,8 @@ def EmptyWorkDirectory():
 def FinishWorkDir(dirname):
   # Verification of validity
   if encoder_configuration.conf.sysdir() != dirname:
-    raise encoder.Error('Dirname was wrong in FinishWorkDir')
+    raise encoder.Error('FinishWorkDir got dirname %s but expected %s'
+                        % (dirname, encoder_configuration.conf.sysdir()))
   shutil.rmtree(dirname)
 
 def TestFileSet():

--- a/lib/test_tools.py
+++ b/lib/test_tools.py
@@ -28,7 +28,9 @@ def InitWorkDir():
   dirname = tempfile.mkdtemp(prefix='codec-unittest-workdir')
   if not os.path.isdir(dirname):
     os.mkdir(dirname)
-  encoder_configuration.conf.override_workdir_for_test(dirname)
+  os.mkdir(dirname + '/workdir')
+  encoder_configuration.conf.override_workdir_for_test(dirname +
+                                                       '/workdir')
   encoder_configuration.conf.override_sysdir_for_test(dirname)
   encoder_configuration.conf.override_scorepath_for_test([])
   return dirname
@@ -61,9 +63,16 @@ def MakeYuvFileWithOneBlankFrame(name):
   """Make an YUV file with one black frame."""
   return MakeYuvFileWithBlankFrames(name, 1)
 
+def EmptyWorkDirectory():
+  dirname = encoder_configuration.conf.workdir()
+  if dirname[0:4] != '/tmp':
+    raise encoder.Error('Workdir is %s, not a tempfile' % dirname)
+  shutil.rmtree(dirname)
+  os.mkdir(dirname)
+
 def FinishWorkDir(dirname):
   # Verification of validity
-  if encoder_configuration.conf.workdir() != dirname:
+  if encoder_configuration.conf.sysdir() != dirname:
     raise encoder.Error('Dirname was wrong in FinishWorkDir')
   shutil.rmtree(dirname)
 
@@ -89,3 +98,6 @@ class FileUsingCodecTest(unittest.TestCase):
   @classmethod
   def tearDownClass(cls):
     FinishWorkDir(cls._workdir)
+
+  def setUp(self):
+    encoder_configuration.conf.override_scorepath_for_test([])


### PR DESCRIPTION
This set of patches allows one to generate data from a combination of local results and imported results,
through the use of a search path to look up encoders and encodings from storage.

It also centralizes the interface between configuration of the encoders and the environment variables used to configure them.
