### PR TITLE
Add recording of a version number for encoder software.

### DIFF
--- a/bin/run_all_tests
+++ b/bin/run_all_tests
@@ -35,10 +35,14 @@ if [ "$MODE" = "full" ]; then
   $LIBDIR/vp8_mpeg_unittest.py
   $LIBDIR/vp8_mpeg_1d_unittest.py
   $LIBDIR/x264_unittest.py
+  $LIBDIR/x264_baseline_unittest.py
+  $LIBDIR/x265_unittest.py
   $LIBDIR/h261_unittest.py
   $LIBDIR/mjpeg_unittest.py
   $LIBDIR/vp9_unittest.py
+  $LIBDIR/openh264_unittest.py
   # Large tests
+  $LIBDIR/hevc_jm_unittest.py
   $LIBDIR/optimizer_largetest.py
 else
   echo "Skipping some tests in mode $MODE"

--- a/lib/encoder.py
+++ b/lib/encoder.py
@@ -37,6 +37,7 @@ import os
 import random
 import re
 import shutil
+import subprocess
 import sys
 
 
@@ -467,6 +468,20 @@ class Codec(object):
     """A short string suitable for displaying on top of a column
     showing parameter values for a given encoder."""
     return ' '.join([option.name for option in self.AllOptions()])
+
+  def EncoderVersion(self):
+    """Return a string representing the version of the codec.
+
+    For internal functions, return the git hash of the software + a modification
+    marker."""
+    # pylint: disable=no-self-use
+    git_hash = subprocess.check_output(['git', 'log', '--format=%h %ad', '-1'],
+                                       shell=False).rstrip()
+    returncode = subprocess.call(['git', 'diff-index', '--quiet', 'HEAD'])
+    if returncode:
+      return 'compare-codecs %s (modified)' % git_hash
+    else:
+      return 'compare-codecs %s' % git_hash
 
 
 class Context(object):

--- a/lib/encoder_unittest.py
+++ b/lib/encoder_unittest.py
@@ -278,6 +278,9 @@ class TestCodec(unittest.TestCase):
     codec = DummyCodec()
     self.assertTrue(codec.option_formatter)
 
+  def test_EncoderVersionExists(self):
+    codec = DummyCodec()
+    self.assertRegexpMatches(codec.EncoderVersion(), r'^compare-codecs')
 
 
 class TestEncoder(unittest.TestCase):

--- a/lib/ffmpeg.py
+++ b/lib/ffmpeg.py
@@ -19,6 +19,8 @@ compatible with the vpxenc-produced qualities.
 """
 import encoder
 import file_codec
+import re
+import subprocess
 
 class FfmpegCodec(file_codec.FileCodec):
 
@@ -54,3 +56,11 @@ class FfmpegCodec(file_codec.FileCodec):
 
   def ResultData(self, encodedfile):
     return {'frame': file_codec.FfmpegFrameInfo(encodedfile)}
+
+  def EncoderVersion(self):
+    version_output = subprocess.check_output([encoder.Tool('ffmpeg'),
+                                              '-version'])
+    match = re.match('(ffmpeg .*) Copyright', version_output)
+    if match:
+      return match.group(0)
+    raise encoder.Error('ffmpeg did not find its version string')

--- a/lib/file_codec.py
+++ b/lib/file_codec.py
@@ -85,6 +85,7 @@ class FileCodec(encoder.Codec):
 
     result['encode_cputime'] = subprocess_cpu
     result['encode_clocktime'] = elapsed_clock
+    result['encoder_version'] = self.EncoderVersion()
     bitrate = videofile.MeasuredBitrate(os.path.getsize(encodedfile))
 
     psnr, decode_cputime, yuv_md5 = self._DecodeFile(
@@ -135,6 +136,9 @@ class FileCodec(encoder.Codec):
       return False
     os.unlink(new_encoded_file)
     return True
+
+  def EncoderVersion(self):
+    raise encoder.Error('File codecs must define their own version')
 
 
 # Tools that may be called upon by the codec implementation if needed.

--- a/lib/file_codec_unittest.py
+++ b/lib/file_codec_unittest.py
@@ -39,6 +39,10 @@ class CopyingCodec(file_codec.FileCodec):
   def DecodeCommandLine(self, videofile, inputfile, outputfile):
     return 'cp %s %s' % (inputfile, outputfile)
 
+  def EncoderVersion(self):
+    return 'CopyingCodec'
+
+
 class CorruptingCodec(file_codec.FileCodec):
   """A "codec" that gives a different result every time."""
   def __init__(self, name='corrupt'):
@@ -58,6 +62,9 @@ class CorruptingCodec(file_codec.FileCodec):
     return 'cp %s %s; truncate -r %s %s' % (
         inputfile, outputfile,
         videofile.filename, outputfile)
+
+  def EncoderVersion(self):
+    return 'CorruptingCodec'
 
 
 class TestFileCodec(test_tools.FileUsingCodecTest):

--- a/lib/file_codec_unittest.py
+++ b/lib/file_codec_unittest.py
@@ -40,7 +40,7 @@ class CopyingCodec(file_codec.FileCodec):
     return 'cp %s %s' % (inputfile, outputfile)
 
   def EncoderVersion(self):
-    return 'CopyingCodec'
+    return 'CopyingCodec v1'
 
 
 class CorruptingCodec(file_codec.FileCodec):
@@ -64,7 +64,7 @@ class CorruptingCodec(file_codec.FileCodec):
         videofile.filename, outputfile)
 
   def EncoderVersion(self):
-    return 'CorruptingCodec'
+    return 'CorruptingCodec v1'
 
 
 class TestFileCodec(test_tools.FileUsingCodecTest):

--- a/lib/hevc_jm.py
+++ b/lib/hevc_jm.py
@@ -19,6 +19,8 @@ compatible with the vpxenc-produced qualities.
 """
 import encoder
 import file_codec
+import re
+import subprocess
 
 
 class HevcCodec(file_codec.FileCodec):
@@ -59,3 +61,14 @@ class HevcCodec(file_codec.FileCodec):
         encoder.Tool('TAppDecoderStatic'),
         encodedfile, yuvfile)
     return commandline
+
+  def EncoderVersion(self):
+    try:
+      subprocess.check_output([encoder.Tool('TAppEncoderStatic')])
+    except subprocess.CalledProcessError, err:
+      helptext = str(err.output)
+      for line in helptext.split('\n'):
+        if re.match('HM software:', line):
+          return line
+      raise encoder.Error('HM version string not found')
+    raise encoder.Error('HM did not return help text as expected')

--- a/lib/hevc_jm_unittest.py
+++ b/lib/hevc_jm_unittest.py
@@ -45,6 +45,11 @@ class TestHevc(test_tools.FileUsingCodecTest):
     # Most codecs should be good at this.
     self.assertLess(40.0, my_optimizer.Score(encoding))
 
+  def test_EncoderVersion(self):
+    codec = hevc_jm.HevcCodec()
+    self.assertRegexpMatches(codec.EncoderVersion(),
+                             r'HM software')
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/lib/openh264.py
+++ b/lib/openh264.py
@@ -15,6 +15,7 @@
 import encoder
 import file_codec
 import os
+import subprocess
 
 
 class OpenH264Codec(file_codec.FileCodec):
@@ -78,3 +79,10 @@ class OpenH264Codec(file_codec.FileCodec):
     more_results = {}
     more_results['frame'] = file_codec.FfmpegFrameInfo(encodedfile)
     return more_results
+
+  def EncoderVersion(self):
+    # openh264 doesn't appear to have a built-in version string. Use the
+    # git checksum instead.
+    git_hash = subprocess.check_output(
+        'cd third_party/openh264; git log --format="%h %ad" -1', shell=True)
+    return 'openh264 %s' % git_hash

--- a/lib/openh264_unittest.py
+++ b/lib/openh264_unittest.py
@@ -59,6 +59,11 @@ class TestOpenH264(test_tools.FileUsingCodecTest):
     self.assertNotEquals(encoding1.result['bitrate'],
                          encoding2.result['bitrate'])
 
+  def test_EncoderVersion(self):
+    codec = openh264.OpenH264Codec()
+    self.assertRegexpMatches(codec.EncoderVersion(),
+                             r'openh264')
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/lib/vp8.py
+++ b/lib/vp8.py
@@ -106,3 +106,4 @@ class Vp8Codec(file_codec.FileCodec):
         if match:
           return match.group(1)
       raise encoder.Error('Did not find vp8 version string')
+    raise encoder.Error('Getting version from vp8 help message failed')

--- a/lib/vp8.py
+++ b/lib/vp8.py
@@ -21,6 +21,8 @@ It tells the generic codec the following:
 """
 import encoder
 import file_codec
+import re
+import subprocess
 
 class Vp8Codec(file_codec.FileCodec):
   def __init__(self, name='vp8'):
@@ -90,3 +92,17 @@ class Vp8Codec(file_codec.FileCodec):
     more_results = {}
     more_results['frame'] = file_codec.MatroskaFrameInfo(encodedfile)
     return more_results
+
+  def EncoderVersion(self):
+    # The vpxenc command line tool outputs the version number of the
+    # encoder as part of its error message on illegal arguments.
+    try:
+      subprocess.check_output([encoder.Tool('vpxenc')],
+                              stderr=subprocess.STDOUT)
+    except Exception, err:
+      version_output = str(err.output)
+      for line in version_output.split('\n'):
+        match = re.match(r'\s+vp8\s+- (.+)$', line)
+        if match:
+          return match.group(1)
+      raise encoder.Error('Did not find vp8 version string')

--- a/lib/vp8_unittest.py
+++ b/lib/vp8_unittest.py
@@ -70,6 +70,10 @@ class TestVp8(test_tools.FileUsingCodecTest):
     value_set_out = codec.ConfigurationFixups(value_set)
     self.assertEqual('-5', value_set_out.GetValue('cpu-used'))
 
+  def test_EncoderVersion(self):
+    codec = vp8.Vp8Codec()
+    self.assertRegexpMatches(codec.EncoderVersion(),
+                             r'WebM Project VP8 Encoder')
 
 if __name__ == '__main__':
   unittest.main()

--- a/lib/vp9.py
+++ b/lib/vp9.py
@@ -73,3 +73,4 @@ class Vp9Codec(file_codec.FileCodec):
         if match:
           return match.group(1)
       raise encoder.Error('Did not find vp9 version string')
+    raise encoder.Error('Getting vp9 version from help message failed')

--- a/lib/vp9.py
+++ b/lib/vp9.py
@@ -21,6 +21,8 @@ It tells the generic codec the following:
 """
 import encoder
 import file_codec
+import re
+import subprocess
 
 class Vp9Codec(file_codec.FileCodec):
   def __init__(self, name='vp9'):
@@ -57,3 +59,17 @@ class Vp9Codec(file_codec.FileCodec):
     more_results = {}
     more_results['frame'] = file_codec.MatroskaFrameInfo(encodedfile)
     return more_results
+
+  def EncoderVersion(self):
+    # The vpxenc command line tool outputs the version number of the
+    # encoder as part of its error message on illegal arguments.
+    try:
+      subprocess.check_output([encoder.Tool('vpxenc')],
+                              stderr=subprocess.STDOUT)
+    except Exception, err:
+      version_output = str(err.output)
+      for line in version_output.split('\n'):
+        match = re.match(r'\s+vp9\s+- (.+)$', line)
+        if match:
+          return match.group(1)
+      raise encoder.Error('Did not find vp9 version string')

--- a/lib/vp9_unittest.py
+++ b/lib/vp9_unittest.py
@@ -65,6 +65,11 @@ class TestVp9(test_tools.FileUsingCodecTest):
     self.assertTrue(encoding1.result)
     self.assertTrue(encoding2.result)
 
+  def test_EncoderVersion(self):
+    codec = vp9.Vp9Codec()
+    self.assertRegexpMatches(codec.EncoderVersion(),
+                             r'WebM Project VP9 Encoder')
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/lib/x264.py
+++ b/lib/x264.py
@@ -18,6 +18,7 @@ of H.264.
 """
 import encoder
 import file_codec
+import subprocess
 
 class X264Codec(file_codec.FileCodec):
   def __init__(self, name='x264', formatter=None):
@@ -85,3 +86,9 @@ class X264Codec(file_codec.FileCodec):
     more_results = {}
     more_results['frame'] = file_codec.MatroskaFrameInfo(encodedfile)
     return more_results
+
+  def EncoderVersion(self):
+    version_output = subprocess.check_output([encoder.Tool('x264'),
+                                              '--version'])
+    # The version is the first line of output.
+    return version_output.split('\n')[0]

--- a/lib/x264_unittest.py
+++ b/lib/x264_unittest.py
@@ -78,6 +78,10 @@ class TestX264(test_tools.FileUsingCodecTest):
     self.assertAlmostEquals(float(one_encoding.Result()['psnr']),
                             float(two_encoding.Result()['psnr']))
 
+  def test_EncoderVersion(self):
+    codec = x264.X264Codec()
+    self.assertRegexpMatches(codec.EncoderVersion(), r'x264 \d')
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/lib/x265.py
+++ b/lib/x265.py
@@ -18,6 +18,7 @@ the HEVC codec.
 """
 import encoder
 import ffmpeg
+import subprocess
 
 
 class X265Codec(ffmpeg.FfmpegCodec):
@@ -63,3 +64,11 @@ class X265Codec(ffmpeg.FfmpegCodec):
                                       encodedfile,
                                       yuvfile)
     return commandline
+
+  def EncoderVersion(self):
+    version_output = subprocess.check_output([encoder.Tool('x265'),
+                                              '--version'],
+                                              stderr=subprocess.STDOUT)
+    # The version is the first line of output.
+    version = version_output.split('\n')[0]
+    return version.replace('[info]: ', '')

--- a/lib/x265_unittest.py
+++ b/lib/x265_unittest.py
@@ -19,7 +19,7 @@ import unittest
 import test_tools
 import x265
 
-class TestX264(test_tools.FileUsingCodecTest):
+class TestX265(test_tools.FileUsingCodecTest):
   def test_Init(self):
     codec = x265.X265Codec()
     self.assertEqual(codec.name, 'x265')
@@ -43,6 +43,10 @@ class TestX264(test_tools.FileUsingCodecTest):
     encoding.Execute()
     # Most codecs should be good at this.
     self.assertLess(40.0, my_optimizer.Score(encoding))
+
+  def test_EncoderVersion(self):
+    codec = x265.X265Codec()
+    self.assertRegexpMatches(codec.EncoderVersion(), r'x265 HEVC')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds a field in the recorded results that gives a version string
for the encoder software used.
This is useful for keeping track of which results come from which
software version.

Fixes #68 