### PR TITLE
Update build scripts

### DIFF
--- a/compile_tools.sh
+++ b/compile_tools.sh
@@ -146,8 +146,13 @@ build_openh264() {
     git clone git@github.com:cisco/openh264.git
   fi
   cd openh264
+  git fetch --tags
   # 7e3c064 is the version that enables the -frin option which will be used in scripts
-  git checkout 7e3c064
+  # This was referenced per April 2015, but is gone from the repo
+  # as of Aug 9, 2016.
+  # git checkout 7e3c064
+  # Version 1.5.0 is from October 2015.
+  git checkout v1.5.0
   make
   cp h264enc $TOOLDIR
   cp h264dec $TOOLDIR

--- a/install_software.sh
+++ b/install_software.sh
@@ -38,10 +38,8 @@ sudo apt-get install ruby1.9.1-dev nodejs
 # So we limit to a jekyll version that builds under 1.9.1.
 sudo gem install jekyll -v 1.5.1
 
-# Install travis linter
-sudo gem install travis-lint
-
 # Install depot_tools - we use the pylint from there
+rm -rf third_party/depot_tools
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git \
    third_party/depot_tools
 


### PR DESCRIPTION
Various scripts to counteract a year of bitrot.

- Drop the Travis linter. It now requires ruby-2.0, and "travis lint"
  is the recommended way anyway.
- Update openh264 to 1.5.0. The checkout we used earlier disappeared.
- Modify install_software.sh to nuke depot_tools before reinstalling