### PR TITLE
Refactoring the disk cache to have directory as an init parameter

### DIFF
--- a/bin/take_snapshot
+++ b/bin/take_snapshot
@@ -26,6 +26,9 @@ if [ -z $CODEC_WORKDIR -o ! -d $CODEC_WORKDIR ]; then
 fi
 
 DESTINATION=$WORKDIR/snapshot
+echo "Removing old snapshot"
+rm -r $DESTINATION
+echo "Creating new snapshot"
 for RESULT in $(find $CODEC_WORKDIR -name '*.result' -o -name 'parameters'); do
   DEST_FILE=$(echo $RESULT | sed -e "s!$CODEC_WORKDIR!$DESTINATION!")
   DEST_DIR=$(dirname $DEST_FILE)

--- a/bin/verify_scores
+++ b/bin/verify_scores
@@ -45,20 +45,24 @@ def ClassifyScoreRelation(old_score, new_score):
     return 'improved'
   return 'worsened'
 
-def VerifyOneTarget(codec_names, rate, videofile, score):
+def VerifyOneTarget(codec_names, rate, videofile, old_scores, score):
   change_counts = collections.Counter()
   for codec_name in codec_names:
     codec = pick_codec.PickCodec(codec_name)
-    my_optimizer = optimizer.Optimizer(codec)
-    bestsofar = my_optimizer.BestEncoding(rate, videofile)
+    old_optimizer = optimizer.Optimizer(codec, scoredir=old_scores)
+    new_optimizer = optimizer.Optimizer(codec)
+    bestsofar = new_optimizer.RebaseEncoding(
+        old_optimizer.BestEncoding(rate, videofile))
+    bestsofar.Recover()
     if score:
       bestsofar.Execute().Store()
     try:
-      old_score = my_optimizer.Score(bestsofar, scoredir='snapshot')
+      old_score = old_optimizer.Score(bestsofar)
     except encoder.Error:
-      print 'No old score for %s, continuing' % (bestsofar.encoder.Hashname())
+      print 'No old score for %s %d %s, continuing' % \
+        (bestsofar.encoder.Hashname(), rate, videofile.filename)
       continue
-    new_score = my_optimizer.Score(bestsofar)
+    new_score = new_optimizer.Score(bestsofar)
     result = ClassifyScoreRelation(old_score, new_score)
     change_counts[result] += 1
     if result != 'no change':
@@ -70,12 +74,12 @@ def VerifyOneTarget(codec_names, rate, videofile, score):
 
   return change_counts
 
-def VerifyResults(codec_names, score):
+def VerifyResults(codec_names, old_scores, score):
   change_counts = collections.Counter()
   for rate, filename in mpeg_settings.MpegFiles().AllFilesAndRates():
     videofile = encoder.Videofile(filename)
     change_counts.update(VerifyOneTarget(codec_names, rate,
-                                         videofile, score))
+                                         videofile, old_scores, score))
     print 'Result so far:', dict(change_counts)
   return change_counts
 
@@ -84,8 +88,10 @@ def main():
   parser.add_argument('codec_names', nargs='*',
                       default=pick_codec.AllCodecNames())
   parser.add_argument('--score', action='store_true', default=False)
+  parser.add_argument('--old_scores', default='snapshot')
   args = parser.parse_args()
-  change_count = VerifyResults(args.codec_names, score=args.score)
+  change_count = VerifyResults(args.codec_names, old_scores=args.old_scores,
+                               score=args.score)
   print 'Change evaluations: ', dict(change_count)
   return 0
 

--- a/lib/encoder.py
+++ b/lib/encoder.py
@@ -733,6 +733,7 @@ class EncodingDiskCache(object):
   """Encoder and encoding information, saved to disk."""
   def __init__(self, context, scoredir=None):
     self.context = context
+    self.bad_encodings = {}
     if scoredir:
       self.workdir = os.path.join(encoder_configuration.conf.sysdir(),
                                   scoredir, context.codec.name)
@@ -772,10 +773,11 @@ class EncodingDiskCache(object):
         videofile or _FileNameToVideofile(full_filename))
       try:
         candidate.Recover()
-      except Error:
-        print 'Ignoring error in file %s' % full_filename
+        candidates.append(candidate)
+      except Error as err:
+        # TODO(hta): Change this to a more specific catch once available.
+        self.bad_encodings[full_filename] = err
         continue
-      candidates.append(candidate)
     return candidates
 
   def _QueryScoredEncodings(self, encoder=None, bitrate=None, videofile=None):

--- a/lib/encoder.py
+++ b/lib/encoder.py
@@ -494,12 +494,12 @@ class Context(object):
   is passed to the context constructor.
   """
 
-  def __init__(self, codec, cache_class=None):
+  def __init__(self, codec, cache_class=None, scoredir=None):
     self.codec = codec
     if cache_class:
-      self.cache = cache_class(self)
+      self.cache = cache_class(self, scoredir)
     else:
-      self.cache = EncodingMemoryCache(self)
+      self.cache = EncodingMemoryCache(self, scoredir)
 
 
 class Encoder(object):
@@ -731,11 +731,15 @@ def _FileNameToVideofile(full_filename):
 
 class EncodingDiskCache(object):
   """Encoder and encoding information, saved to disk."""
-  def __init__(self, context):
+  def __init__(self, context, scoredir=None):
     self.context = context
-    # Default work directory is current directory.
-    self.workdir = '%s/%s' % (encoder_configuration.conf.workdir(),
-                              context.codec.name)
+    if scoredir:
+      self.workdir = os.path.join(encoder_configuration.conf.sysdir(),
+                                  scoredir, context.codec.name)
+    else:
+      # Default work directory.
+      self.workdir = os.path.join(encoder_configuration.conf.workdir(),
+                                  context.codec.name)
     if not os.path.isdir(self.workdir):
       os.mkdir(self.workdir)
 
@@ -766,7 +770,11 @@ class EncodingDiskCache(object):
         encoder or self._FileNameToEncoder(full_filename),
         bitrate or _FileNameToBitrate(full_filename),
         videofile or _FileNameToVideofile(full_filename))
-      candidate.Recover()
+      try:
+        candidate.Recover()
+      except Error:
+        print 'Ignoring error in file %s' % full_filename
+        continue
       candidates.append(candidate)
     return candidates
 
@@ -848,22 +856,16 @@ class EncodingDiskCache(object):
   def RemoveEncoder(self, hashname):
     shutil.rmtree(os.path.join(self.workdir, hashname))
 
-  def StoreEncoding(self, encoding, workdir=None):
+  def StoreEncoding(self, encoding):
     """Stores an encoding object on disk.
 
     An encoding object consists of its result (if executed).
     The bitrate is encoded as a directory, the videofilename
     is encoded as part of the output filename.
     """
-    if workdir:
-      dirname = os.path.join(workdir,
-                             self.context.codec.name,
-                             encoding.encoder.Hashname(),
-                             self.context.codec.SpeedGroup(encoding.bitrate))
-    else:
-      dirname = os.path.join(self.workdir,
-                             encoding.encoder.Hashname(),
-                             self.context.codec.SpeedGroup(encoding.bitrate))
+    dirname = os.path.join(self.workdir,
+                           encoding.encoder.Hashname(),
+                           self.context.codec.SpeedGroup(encoding.bitrate))
     if not os.path.isdir(dirname):
       os.mkdir(dirname)
     if not encoding.result:
@@ -872,17 +874,14 @@ class EncodingDiskCache(object):
     with open('%s/%s.result' % (dirname, videoname), 'w') as resultfile:
       json.dump(encoding.result, resultfile, indent=2)
 
-  def ReadEncodingResult(self, encoding, scoredir=None):
+  def ReadEncodingResult(self, encoding):
     """Reads an encoding result back from storage, if present.
 
     None is returned if file does not exist.
     If scoredir is given, only that directory is searched.
     If it is not given, all directories in the search path are searched."""
 
-    if scoredir:
-      searchpath = [os.path.join(scoredir, self.context.codec.name)]
-    else:
-      searchpath = self.SearchPathForScores()
+    searchpath = self.SearchPathForScores()
 
     for workdir in searchpath:
       dirname = os.path.join(workdir, encoding.encoder.Hashname(),
@@ -903,13 +902,16 @@ class EncodingDiskCache(object):
 
 class EncodingMemoryCache(object):
   """Encoder and encoding information, in-memory only. For testing."""
-  def __init__(self, context):
+  def __init__(self, context, scoredir=None):
+    if scoredir:
+      raise Error('Cannot have scoredir on a memory cache')
     self.context = context
     self.encoders = {}
     self.encodings = []
+    self.workdir = '/not-valid-file/' + self.context.codec.name
 
   def WorkDir(self):
-    return '/not-valid-file/' + self.context.codec.name
+    return self.workdir
 
   def AllScoredEncodings(self, bitrate, videofile):
     result = []


### PR DESCRIPTION
Running calculations of scores & best scores over several directories
turned out to be complex if directory was passed as a call parameter.

This refactoring makes it part of the init parameters of the optimizer,
the context and the cache.

This means that one has to have functions for "adopting" an encoding
into the other context.

Fixes #77